### PR TITLE
feat: add RemoveUserFromPlan functionality

### DIFF
--- a/core/mock_QuotaService.go
+++ b/core/mock_QuotaService.go
@@ -2008,6 +2008,57 @@ func (_c *MockQuotaService_RecordUpload_Call) RunAndReturn(run func(userID uint,
 	return _c
 }
 
+// RemoveUserFromPlan provides a mock function for the type MockQuotaService
+func (_mock *MockQuotaService) RemoveUserFromPlan(userID uint) error {
+	ret := _mock.Called(userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveUserFromPlan")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(uint) error); ok {
+		r0 = returnFunc(userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockQuotaService_RemoveUserFromPlan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveUserFromPlan'
+type MockQuotaService_RemoveUserFromPlan_Call struct {
+	*mock.Call
+}
+
+// RemoveUserFromPlan is a helper method to define mock.On call
+//   - userID uint
+func (_e *MockQuotaService_Expecter) RemoveUserFromPlan(userID interface{}) *MockQuotaService_RemoveUserFromPlan_Call {
+	return &MockQuotaService_RemoveUserFromPlan_Call{Call: _e.mock.On("RemoveUserFromPlan", userID)}
+}
+
+func (_c *MockQuotaService_RemoveUserFromPlan_Call) Run(run func(userID uint)) *MockQuotaService_RemoveUserFromPlan_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 uint
+		if args[0] != nil {
+			arg0 = args[0].(uint)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuotaService_RemoveUserFromPlan_Call) Return(err error) *MockQuotaService_RemoveUserFromPlan_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockQuotaService_RemoveUserFromPlan_Call) RunAndReturn(run func(userID uint) error) *MockQuotaService_RemoveUserFromPlan_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResetAllowance provides a mock function for the type MockQuotaService
 func (_mock *MockQuotaService) ResetAllowance(userID uint) error {
 	ret := _mock.Called(userID)

--- a/core/quota.go
+++ b/core/quota.go
@@ -42,6 +42,7 @@ type QuotaService interface {
 	SetDefaultQuotaPlan(planID uint) error
 	GetDefaultQuotaPlan() (*models.QuotaPlan, error)
 	AssignUserToPlan(userID uint, planID uint) error
+	RemoveUserFromPlan(userID uint) error
 
 	// Allowance Management (for ALLOWANCE policy)
 	AddAllowance(userID uint, storage, upload, download uint64) error

--- a/internal/db/models/user_quota_config.go
+++ b/internal/db/models/user_quota_config.go
@@ -18,7 +18,7 @@ type UserQuotaConfig struct {
 	StorageThreshold   *int64
 	UploadThreshold    *int64
 	DownloadThreshold  *int64
-	
+
 	// Relationships
 	AllowanceGrants []*AllowanceGrant `gorm:"foreignKey:UserID;references:UserID"`
 }
@@ -29,20 +29,17 @@ func (UserQuotaConfig) TableName() string {
 }
 
 // BeforeCreate validates the UserQuotaConfig model before creation
-func (u *UserQuotaConfig) BeforeCreate(tx *gorm.DB) error {
-	if u.UserID <= 0 {
-		return ErrInvalidUserID
-	}
-
-	if !u.EnforcementPolicy.IsValid() {
-		return ErrInvalidEnforcementPolicy
-	}
-
-	return nil
+func (u *UserQuotaConfig) BeforeCreate(_ *gorm.DB) error {
+	return u.validate()
 }
 
 // BeforeUpdate validates the UserQuotaConfig model before update
-func (u *UserQuotaConfig) BeforeUpdate(tx *gorm.DB) error {
+func (u *UserQuotaConfig) BeforeUpdate(_ *gorm.DB) error {
+	return u.validate()
+}
+
+// validate performs common validation for UserQuotaConfig
+func (u *UserQuotaConfig) validate() error {
 	if u.UserID <= 0 {
 		return ErrInvalidUserID
 	}

--- a/internal/service/managers/config.go
+++ b/internal/service/managers/config.go
@@ -43,13 +43,13 @@ func (cm *ConfigManager) ResolveEffectiveLimits(userID uint) (*pluginCore.Effect
 	cm.logger.Debug("Resolving effective limits for user", zap.Uint("userID", userID))
 
 	// Get user's quota config
-	config, err := cm.GetUserQuotaConfig(userID)
+	cfg, err := cm.GetUserQuotaConfig(userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user quota config: %w", err)
 	}
 
 	// Resolve limits using the limit resolver
-	limits, err := cm.limitResolver.ResolveEffectiveLimits(config, pluginModels.EnforcementPolicy(config.EnforcementPolicy))
+	limits, err := cm.limitResolver.ResolveEffectiveLimits(cfg, pluginModels.EnforcementPolicy(cfg.EnforcementPolicy))
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve effective limits: %w", err)
 	}

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -323,24 +323,58 @@ func (s *QuotaServiceDefault) AssignUserToPlan(userID uint, planID uint) error {
 		return fmt.Errorf("service context or database not initialized")
 	}
 
+	if userID == 0 {
+		return fmt.Errorf("invalid user ID")
+	}
+
 	db := s.ctx.DB()
 
 	// Perform both operations atomically in a transaction
 	return db.Transaction(func(tx *gorm.DB) error {
 		// First, ensure the user has a quota config
-		cfg := &models.UserQuotaConfig{
+		result := tx.Where("user_id = ?", userID).FirstOrCreate(&models.UserQuotaConfig{
 			UserID:            userID,
 			EnforcementPolicy: models.EnforcementPolicyHardLimits,
-		}
-
-		result := tx.Where("user_id = ?", userID).FirstOrCreate(cfg)
+		})
 		if result.Error != nil {
 			return fmt.Errorf("failed to get or create user quota config: %w", result.Error)
 		}
 
 		// Update the user's quota config with the plan ID
-		if err := tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).Update("quota_plan_id", planID).Error; err != nil {
+		if err := tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", planID).Error; err != nil {
 			return fmt.Errorf("failed to assign user to plan: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// RemoveUserFromPlan removes a user from their assigned quota plan
+func (s *QuotaServiceDefault) RemoveUserFromPlan(userID uint) error {
+	if s.ctx == nil || s.ctx.DB() == nil {
+		return fmt.Errorf("service context or database not initialized")
+	}
+
+	if userID == 0 {
+		return fmt.Errorf("invalid user ID")
+	}
+
+	db := s.ctx.DB()
+
+	// Perform the operation in a transaction
+	return db.Transaction(func(tx *gorm.DB) error {
+		// First, ensure the user has a quota config
+		result := tx.Where("user_id = ?", userID).FirstOrCreate(&models.UserQuotaConfig{
+			UserID:            userID,
+			EnforcementPolicy: models.EnforcementPolicyHardLimits,
+		})
+		if result.Error != nil {
+			return fmt.Errorf("failed to get or create user quota config: %w", result.Error)
+		}
+
+		// Update the user's quota config to remove the plan ID
+		if err := tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", nil).Error; err != nil {
+			return fmt.Errorf("failed to remove user from plan: %w", err)
 		}
 
 		return nil

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -327,6 +327,12 @@ func (s *QuotaServiceDefault) AssignUserToPlan(userID uint, planID uint) error {
 		return fmt.Errorf("invalid user ID")
 	}
 
+	// Verify that the plan exists
+	_, err := s.planManager.GetQuotaPlanByID(uint64(planID))
+	if err != nil {
+		return fmt.Errorf("failed to verify quota plan existence: %w", err)
+	}
+
 	db := s.ctx.DB()
 
 	// Perform both operations atomically in a transaction

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -367,24 +367,12 @@ func (s *QuotaServiceDefault) RemoveUserFromPlan(userID uint) error {
 
 	db := s.ctx.DB()
 
-	// Perform the operation in a transaction
-	return db.Transaction(func(tx *gorm.DB) error {
-		// First, ensure the user has a quota config
-		result := tx.Where("user_id = ?", userID).FirstOrCreate(&models.UserQuotaConfig{
-			UserID:            userID,
-			EnforcementPolicy: models.EnforcementPolicyHardLimits,
-		})
-		if result.Error != nil {
-			return fmt.Errorf("failed to get or create user quota config: %w", result.Error)
-		}
+	// Update the quota config to remove the plan ID (no-op if user doesn't exist)
+	if err := db.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", nil).Error; err != nil {
+		return fmt.Errorf("failed to remove user from plan: %w", err)
+	}
 
-		// Update the user's quota config to remove the plan ID
-		if err := tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", nil).Error; err != nil {
-			return fmt.Errorf("failed to remove user from plan: %w", err)
-		}
-
-		return nil
-	})
+	return nil
 }
 
 // Allowance Management

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -382,6 +382,43 @@ func TestQuotaServiceDefault_GetAllowanceBalance_Success(t *testing.T) {
 	}, testOptions())
 }
 
+// TestQuotaServiceDefault_RemoveUserFromPlan_Success tests successful removal of user from plan
+func TestQuotaServiceDefault_RemoveUserFromPlan_Success(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// First assign user to a plan
+		userID := uint(testUserID)
+
+		// Create a plan first
+		plan := &pluginModels.QuotaPlan{
+			Name:        "test_plan",
+			Description: "Test quota plan",
+		}
+		err := ctx.DB().Create(plan).Error
+		require.NoError(t, err)
+
+		// Assign user to plan
+		err = quotaService.AssignUserToPlan(userID, plan.ID)
+		require.NoError(t, err)
+
+		// Verify user is assigned to plan
+		cfg, err := quotaService.GetQuotaConfig(userID)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.QuotaPlanID)
+		assert.Equal(t, uint64(plan.ID), *cfg.QuotaPlanID)
+
+		// Remove user from plan
+		err = quotaService.RemoveUserFromPlan(userID)
+		require.NoError(t, err)
+
+		// Verify user is no longer assigned to plan
+		cfg, err = quotaService.GetQuotaConfig(userID)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.QuotaPlanID)
+	}, testOptions())
+}
+
 // TestQuotaServiceDefault_ResetAllowance_Success tests successful allowance reset
 func TestQuotaServiceDefault_ResetAllowance_Success(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {


### PR DESCRIPTION
* Added `RemoveUserFromPlan` method to `QuotaService` interface and its implementation in `QuotaServiceDefault`
* Implemented mock support for `RemoveUserFromPlan` in `MockQuotaService`
* Refactored `UserQuotaConfig` validation to use a common `validate()` method
* Added test case for successful removal of user from quota plan
* Minor variable naming improvement in config manager


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - You can now unassign users from quota plans.
  - Added validation to prevent assigning or removing plans for invalid user IDs.

- **Refactor**
  - Centralized validation for user quota configurations to improve consistency.

- **Tests**
  - Added tests verifying successful removal of a user from a quota plan and mock support for removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->