### PR TITLE
fix(db): remove StatementBegin/StatementEnd from MySQL migration

### DIFF
--- a/internal/db/migrations/mysql/20250604064114_init.sql
+++ b/internal/db/migrations/mysql/20250604064114_init.sql
@@ -1,5 +1,4 @@
 -- +goose Up
--- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS user_quotas (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     user_id BIGINT UNSIGNED NOT NULL,
@@ -117,14 +116,11 @@ CREATE TABLE IF NOT EXISTS allowance_consumptions (
     INDEX idx_usage_detail_id (usage_detail_id),
     INDEX idx_consumption_date (consumption_date)
 );
--- +goose StatementEnd
 
 -- +goose Down
--- +goose StatementBegin
 DROP TABLE allowance_consumptions;
 DROP TABLE allowance_grants;
 DROP TABLE user_quota_configs;
 DROP TABLE quota_plans;
 DROP TABLE user_usage_details;
 DROP TABLE user_quotas;
--- +goose StatementEnd


### PR DESCRIPTION
Remove goose StatementBegin/StatementEnd directives from MySQL migration file. These directives cause MySQL to attempt all CREATE TABLE statements as a single query, which fails with Error 1064.

---

<!-- kody-pr-summary:start -->
This pull request fixes a MySQL database migration issue by removing the `-- +goose StatementBegin` and `-- +goose StatementEnd` annotations from the migration file.

**Changes Made:**
- Removed transaction block markers (`StatementBegin`/`StatementEnd`) from both the "Up" and "Down" migration sections in the MySQL initialization migration

**Functional Impact:**
This resolves compatibility issues with MySQL's DDL execution model. MySQL automatically commits transactions for each DDL statement (CREATE TABLE, DROP TABLE, etc.), making the explicit statement block wrappers unnecessary and potentially problematic for migration tooling. The migration will now execute individual schema changes without attempting to wrap them in explicit transaction blocks, ensuring reliable database schema initialization on MySQL.
<!-- kody-pr-summary:end -->