### PR TITLE
fix: add defensive programming for duplicate quota plan names

### DIFF
--- a/core/mock_QuotaPlanManager.go
+++ b/core/mock_QuotaPlanManager.go
@@ -167,3 +167,71 @@ func (_c *MockQuotaPlanManager_GetQuotaPlanByID_Call) RunAndReturn(run func(ctx 
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetQuotaPlanByName provides a mock function for the type MockQuotaPlanManager
+func (_mock *MockQuotaPlanManager) GetQuotaPlanByName(ctx context.Context, name string) (*models.QuotaPlan, error) {
+	ret := _mock.Called(ctx, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetQuotaPlanByName")
+	}
+
+	var r0 *models.QuotaPlan
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*models.QuotaPlan, error)); ok {
+		return returnFunc(ctx, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *models.QuotaPlan); ok {
+		r0 = returnFunc(ctx, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.QuotaPlan)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockQuotaPlanManager_GetQuotaPlanByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetQuotaPlanByName'
+type MockQuotaPlanManager_GetQuotaPlanByName_Call struct {
+	*mock.Call
+}
+
+// GetQuotaPlanByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+func (_e *MockQuotaPlanManager_Expecter) GetQuotaPlanByName(ctx interface{}, name interface{}) *MockQuotaPlanManager_GetQuotaPlanByName_Call {
+	return &MockQuotaPlanManager_GetQuotaPlanByName_Call{Call: _e.mock.On("GetQuotaPlanByName", ctx, name)}
+}
+
+func (_c *MockQuotaPlanManager_GetQuotaPlanByName_Call) Run(run func(ctx context.Context, name string)) *MockQuotaPlanManager_GetQuotaPlanByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuotaPlanManager_GetQuotaPlanByName_Call) Return(quotaPlan *models.QuotaPlan, err error) *MockQuotaPlanManager_GetQuotaPlanByName_Call {
+	_c.Call.Return(quotaPlan, err)
+	return _c
+}
+
+func (_c *MockQuotaPlanManager_GetQuotaPlanByName_Call) RunAndReturn(run func(ctx context.Context, name string) (*models.QuotaPlan, error)) *MockQuotaPlanManager_GetQuotaPlanByName_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/core/quota.go
+++ b/core/quota.go
@@ -86,5 +86,6 @@ type QuotaService interface {
 // QuotaPlanManager abstracts database operations related to quota plans
 type QuotaPlanManager interface {
 	GetQuotaPlanByID(ctx context.Context, id uint64) (*models.QuotaPlan, error)
+	GetQuotaPlanByName(ctx context.Context, name string) (*models.QuotaPlan, error)
 	GetDefaultQuotaPlan(ctx context.Context) (*models.QuotaPlan, error)
 }

--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -285,6 +285,11 @@ func (e *QuotaAdminExtension) handleCreatePlan(c echo.Context) error {
 	}
 
 	if err := e.quotaService.CreateQuotaPlan(reqCtx, plan); err != nil {
+		if errors.Is(err, models.ErrQuotaPlanNameExists) {
+			e.Logger().Error("quota plan with this name already exists", zap.Error(err))
+			apiErr := NewError(ErrKeyPlanNameExists, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 		e.Logger().Error("failed to create quota plan", zap.Error(err))
 		apiErr := NewError(ErrKeyPlanCreateFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -19,6 +19,7 @@ const (
 	ErrKeyInvalidPlanID       core.ErrorType = "INVALID_PLAN_ID"
 	ErrKeyInvalidGrantID      core.ErrorType = "INVALID_GRANT_ID"
 	ErrKeyPlanCreateFailed    core.ErrorType = "PLAN_CREATE_FAILED"
+	ErrKeyPlanNameExists      core.ErrorType = "PLAN_NAME_EXISTS"
 	ErrKeyPlanUpdateFailed    core.ErrorType = "PLAN_UPDATE_FAILED"
 	ErrKeyPlanDeleteFailed    core.ErrorType = "PLAN_DELETE_FAILED"
 	ErrKeyGrantCreateFailed   core.ErrorType = "GRANT_CREATE_FAILED"
@@ -101,6 +102,7 @@ func init() {
 		ErrKeyInvalidPlanID:       {Key: ErrKeyInvalidPlanID, Message: "Invalid plan ID format"},
 		ErrKeyInvalidGrantID:      {Key: ErrKeyInvalidGrantID, Message: "Invalid grant ID format"},
 		ErrKeyPlanCreateFailed:    {Key: ErrKeyPlanCreateFailed, Message: "Failed to create quota plan"},
+		ErrKeyPlanNameExists:      {Key: ErrKeyPlanNameExists, Message: "Quota plan with this name already exists"},
 		ErrKeyPlanUpdateFailed:    {Key: ErrKeyPlanUpdateFailed, Message: "Failed to update quota plan"},
 		ErrKeyPlanDeleteFailed:    {Key: ErrKeyPlanDeleteFailed, Message: "Failed to delete quota plan"},
 		ErrKeyGrantCreateFailed:   {Key: ErrKeyGrantCreateFailed, Message: "Failed to create grant"},
@@ -126,6 +128,7 @@ func init() {
 		ErrKeyInvalidPlanID:        http.StatusBadRequest,
 		ErrKeyInvalidGrantID:      http.StatusBadRequest,
 		ErrKeyPlanCreateFailed:    http.StatusInternalServerError,
+		ErrKeyPlanNameExists:      http.StatusConflict,
 		ErrKeyPlanUpdateFailed:    http.StatusInternalServerError,
 		ErrKeyPlanDeleteFailed:    http.StatusInternalServerError,
 		ErrKeyGrantCreateFailed:   http.StatusInternalServerError,

--- a/internal/db/models/errors.go
+++ b/internal/db/models/errors.go
@@ -36,6 +36,7 @@ var (
 	ErrInvalidDownloadTotalLimit  = errors.New("download_total_limit must be greater than or equal to 0")
 	ErrThresholdExceedsLimit      = errors.New("threshold cannot be greater than limit")
 	ErrQuotaPlanNotFound          = errors.New("quota plan not found")
+	ErrQuotaPlanNameExists       = errors.New("quota plan with this name already exists")
 	ErrNoDefaultQuotaPlan         = errors.New("no default quota plan set")
 	ErrInsufficientAllowance      = errors.New("insufficient allowance")
 )

--- a/internal/service/policies/quota_plan_manager.go
+++ b/internal/service/policies/quota_plan_manager.go
@@ -55,6 +55,33 @@ func (q *QuotaPlanManagerDefault) GetQuotaPlanByID(ctx context.Context, id uint6
 	return &plan, nil
 }
 
+// GetQuotaPlanByName retrieves a quota plan by its name
+func (q *QuotaPlanManagerDefault) GetQuotaPlanByName(ctx context.Context, name string) (*models.QuotaPlan, error) {
+	ctx, span := core.TraceMethod(ctx, "QuotaPlanManagerDefault.GetQuotaPlanByName")
+	defer span.End()
+
+	q.logger.Debug("GetQuotaPlanByName: retrieving quota plan by name", zap.String("name", name))
+
+	var plan models.QuotaPlan
+	err := q.db.WithContext(ctx).Where("name = ?", name).First(&plan).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			q.logger.Debug("GetQuotaPlanByName: quota plan not found", zap.String("name", name))
+			return nil, fmt.Errorf("%w: %s", models.ErrQuotaPlanNotFound, name)
+		}
+		q.logger.Error("GetQuotaPlanByName: failed to retrieve quota plan",
+			zap.String("name", name),
+			zap.Error(err))
+		return nil, fmt.Errorf("failed to retrieve quota plan: %w", err)
+	}
+
+	q.logger.Debug("GetQuotaPlanByName: quota plan retrieved successfully",
+		zap.Uint("id", plan.ID),
+		zap.String("name", plan.Name))
+
+	return &plan, nil
+}
+
 // GetDefaultQuotaPlan retrieves the default active quota plan
 func (q *QuotaPlanManagerDefault) GetDefaultQuotaPlan(ctx context.Context) (*models.QuotaPlan, error) {
 	ctx, span := core.TraceMethod(ctx, "QuotaPlanManagerDefault.GetDefaultQuotaPlan")

--- a/internal/service/policies/quota_plan_manager_integration_test.go
+++ b/internal/service/policies/quota_plan_manager_integration_test.go
@@ -118,3 +118,110 @@ func TestQuotaPlanManagerDefault_GetDefaultQuotaPlan_Inactive(t *testing.T) {
 		assert.Equal(t, "Inactive Default Plan", result.Name)
 	}, pluginTesting.TestOptions())
 }
+
+func TestQuotaPlanManagerDefault_GetQuotaPlanByName_ValidName(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Create a test quota plan with unique name
+		planName := "Enterprise Plan " + t.Name()
+		plan := createTestQuotaPlan(t, ctx, planName, true, &testPlanLimits{
+			storageLimit:       1000,
+			uploadDailyLimit:   500,
+			downloadDailyLimit: 750,
+			uploadTotalLimit:   5000,
+			downloadTotalLimit: 10000,
+		})
+
+		manager := NewQuotaPlanManager(ctx, ctx.DB(), ctx.Logger())
+
+		result, err := manager.GetQuotaPlanByName(ctx, planName)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, planName, result.Name)
+		assert.Equal(t, plan.ID, result.ID)
+		assert.Equal(t, plan.StorageLimit, result.StorageLimit)
+		assert.Equal(t, plan.UploadDailyLimit, result.UploadDailyLimit)
+		assert.Equal(t, plan.DownloadDailyLimit, result.DownloadDailyLimit)
+		assert.Equal(t, plan.UploadTotalLimit, result.UploadTotalLimit)
+		assert.Equal(t, plan.DownloadTotalLimit, result.DownloadTotalLimit)
+	}, pluginTesting.TestOptions())
+}
+
+func TestQuotaPlanManagerDefault_GetQuotaPlanByName_NonExistentName(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		manager := NewQuotaPlanManager(ctx, ctx.DB(), ctx.Logger())
+
+		result, err := manager.GetQuotaPlanByName(ctx, "Non Existent Plan Name")
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, models.ErrQuotaPlanNotFound)
+	}, pluginTesting.TestOptions())
+}
+
+func TestQuotaPlanManagerDefault_GetQuotaPlanByName_CaseSensitive(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Create a plan with specific casing
+		planName := "Enterprise Plan"
+		createTestQuotaPlan(t, ctx, planName, true, &testPlanLimits{
+			storageLimit:       1000,
+			uploadDailyLimit:   500,
+			downloadDailyLimit: 750,
+			uploadTotalLimit:   5000,
+			downloadTotalLimit: 10000,
+		})
+
+		manager := NewQuotaPlanManager(ctx, ctx.DB(), ctx.Logger())
+
+		// Try to find with different casing
+		result, err := manager.GetQuotaPlanByName(ctx, "enterprise plan")
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, models.ErrQuotaPlanNotFound)
+
+		// Try to find with exact casing
+		result, err = manager.GetQuotaPlanByName(ctx, planName)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, planName, result.Name)
+	}, pluginTesting.TestOptions())
+}
+
+func TestQuotaPlanManagerDefault_GetQuotaPlanByName_MultiplePlans(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Create multiple plans with different names (only first is default)
+		plan1 := createTestQuotaPlan(t, ctx, "Plan One", true, &testPlanLimits{
+			storageLimit:       1000,
+			uploadDailyLimit:   500,
+			downloadDailyLimit: 750,
+			uploadTotalLimit:   5000,
+			downloadTotalLimit: 10000,
+		})
+
+		plan2 := createTestQuotaPlan(t, ctx, "Plan Two", false, &testPlanLimits{
+			storageLimit:       2000,
+			uploadDailyLimit:   1000,
+			downloadDailyLimit: 1500,
+			uploadTotalLimit:   10000,
+			downloadTotalLimit: 20000,
+		})
+
+		manager := NewQuotaPlanManager(ctx, ctx.DB(), ctx.Logger())
+
+		// Find first plan
+		result1, err := manager.GetQuotaPlanByName(ctx, "Plan One")
+		require.NoError(t, err)
+		assert.NotNil(t, result1)
+		assert.Equal(t, "Plan One", result1.Name)
+		assert.Equal(t, plan1.ID, result1.ID)
+
+		// Find second plan
+		result2, err := manager.GetQuotaPlanByName(ctx, "Plan Two")
+		require.NoError(t, err)
+		assert.NotNil(t, result2)
+		assert.Equal(t, "Plan Two", result2.Name)
+		assert.Equal(t, plan2.ID, result2.ID)
+
+		// Verify they are different plans
+		assert.NotEqual(t, result1.ID, result2.ID)
+	}, pluginTesting.TestOptions())
+}
+

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -2,7 +2,9 @@ package quota
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -355,8 +357,16 @@ func (s *QuotaServiceDefault) CreateQuotaPlan(ctx context.Context, plan *models.
 	}
 
 	// Check if a plan with the same name already exists
+// Note: We perform this pre-flight check as an optimization for early feedback,
+// but we also handle UNIQUE constraint violations from the database during creation
+// to prevent race conditions (TOCTOU) where concurrent requests bypass this check.
 	existingPlan, err := s.planManager.GetQuotaPlanByName(ctx, plan.Name)
-	if err == nil && existingPlan != nil {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		// Real database error (connection, timeout, etc.) - fail fast
+		return fmt.Errorf("failed to check for existing plan: %w", err)
+	}
+	if existingPlan != nil {
+		// Plan already exists - return conflict error
 		return models.ErrQuotaPlanNameExists
 	}
 
@@ -367,6 +377,10 @@ func (s *QuotaServiceDefault) CreateQuotaPlan(ctx context.Context, plan *models.
 			if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 				return tx.Create(plan)
 			}); err != nil {
+				// Check for unique constraint violation and return proper error
+				if isUniqueConstraintError(err) {
+					return models.ErrQuotaPlanNameExists
+				}
 				return fmt.Errorf("failed to create quota plan: %w", err)
 			}
 			policies.PlanOperations.WithLabelValues(policies.LabelPlanOperationCreate).Inc()
@@ -1016,4 +1030,41 @@ func (s *QuotaServiceDefault) GetConfigManager() pluginCore.ConfigManager {
 // GetConfig implements core.Configurable
 func (s *QuotaServiceDefault) GetConfig() (any, error) {
 	return &config.QuotaConfig{}, nil
+}
+
+// isUniqueConstraintError checks if an error is a unique constraint violation
+// for the quota_plan name field. This handles both MySQL and SQLite errors.
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check the error message for unique constraint indicators
+	errStr := err.Error()
+	
+	// MySQL unique constraint violation
+	// Error 1062: Duplicate entry
+	// Error 1586: Duplicate entry
+	if strings.Contains(errStr, "Duplicate entry") &&
+	   strings.Contains(errStr, "key") &&
+	   strings.Contains(errStr, "quota_plans") {
+		return true
+	}
+
+	// SQLite unique constraint violation
+	if strings.Contains(errStr, "UNIQUE constraint failed") {
+		return true
+	}
+
+	// GORM's built-in duplicate key error
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+
+	// Additional check for MySQL ErrDuplicateEntry
+	// This requires checking for the MySQL driver error
+	// Note: This is a simplified check; in production you might want to
+	// use type assertions to check for specific driver errors
+	
+	return false
 }

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -354,7 +354,13 @@ func (s *QuotaServiceDefault) CreateQuotaPlan(ctx context.Context, plan *models.
 		return fmt.Errorf("database not initialized")
 	}
 
-	err := core.MetricTrack(
+	// Check if a plan with the same name already exists
+	existingPlan, err := s.planManager.GetQuotaPlanByName(ctx, plan.Name)
+	if err == nil && existingPlan != nil {
+		return models.ErrQuotaPlanNameExists
+	}
+
+	err = core.MetricTrack(
 		nil,
 		policies.PlanOperationsErr.WithLabelValues(policies.LabelPlanOperationCreate),
 		func() error {

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -264,6 +264,147 @@ func TestQuotaServiceDefault_CreateQuotaPlan_Success(t *testing.T) {
 	}, testOptions())
 }
 
+// TestQuotaServiceDefault_CreateQuotaPlan_DuplicateName tests that duplicate plan names are rejected
+func TestQuotaServiceDefault_CreateQuotaPlan_DuplicateName(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Create first plan
+		plan1 := &pluginModels.QuotaPlan{
+			Name:        "Enterprise Plan",
+			Description: "First enterprise plan",
+			StorageLimit:       1000,
+			UploadDailyLimit:   500,
+			DownloadDailyLimit: 750,
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan1)
+		require.NoError(t, err)
+		require.NotZero(t, plan1.ID)
+
+		// Try to create second plan with same name
+		plan2 := &pluginModels.QuotaPlan{
+			Name:        "Enterprise Plan", // Duplicate name
+			Description: "Second enterprise plan",
+			StorageLimit:       2000,
+			UploadDailyLimit:   1000,
+			DownloadDailyLimit: 1500,
+		}
+		err = quotaService.CreateQuotaPlan(ctx, plan2)
+
+		// Verify error is returned
+		require.Error(t, err)
+		assert.ErrorIs(t, err, pluginModels.ErrQuotaPlanNameExists)
+
+		// Verify second plan was not created in DB
+		var count int64
+		err = ctx.DB().Model(&pluginModels.QuotaPlan{}).Where("name = ?", "Enterprise Plan").Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "Should only have one plan with this name")
+
+		// Verify first plan is still intact
+		var savedPlan pluginModels.QuotaPlan
+		err = ctx.DB().Where("name = ?", "Enterprise Plan").First(&savedPlan).Error
+		require.NoError(t, err)
+		assert.Equal(t, plan1.ID, savedPlan.ID)
+		assert.Equal(t, "First enterprise plan", savedPlan.Description)
+		assert.Equal(t, int64(1000), savedPlan.StorageLimit)
+	}, testOptions())
+}
+
+// TestQuotaServiceDefault_CreateQuotaPlan_DuplicatePlanNames tests multiple duplicate attempts
+func TestQuotaServiceDefault_CreateQuotaPlan_DuplicatePlanNames(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Create first plan
+		plan1 := &pluginModels.QuotaPlan{
+			Name:        "Standard Plan",
+			Description: "Standard tier",
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan1)
+		require.NoError(t, err)
+
+		// Attempt to create duplicate multiple times
+		for i := 0; i < 3; i++ {
+			duplicatePlan := &pluginModels.QuotaPlan{
+				Name:        "Standard Plan",
+				Description: fmt.Sprintf("Duplicate attempt %d", i+1),
+			}
+			err = quotaService.CreateQuotaPlan(ctx, duplicatePlan)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, pluginModels.ErrQuotaPlanNameExists)
+		}
+
+		// Verify only one plan exists
+		var count int64
+		err = ctx.DB().Model(&pluginModels.QuotaPlan{}).Where("name = ?", "Standard Plan").Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+	}, testOptions())
+}
+
+// TestQuotaServiceDefault_CreateQuotaPlan_SimilarNames tests that similar but different names are allowed
+func TestQuotaServiceDefault_CreateQuotaPlan_SimilarNames(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Create plans with similar but different names
+		planNames := []string{
+			"Basic Plan",
+			"Basic Plan Pro",
+			"Basic Plan Premium",
+			"basIC PLAN", // Case-sensitive test
+		}
+
+		for _, name := range planNames {
+			plan := &pluginModels.QuotaPlan{
+				Name:        name,
+				Description: fmt.Sprintf("Plan for %s", name),
+			}
+			err := quotaService.CreateQuotaPlan(ctx, plan)
+			require.NoError(t, err, "Should be able to create plan with name: %s", name)
+		}
+
+		// Verify all plans were created
+		var count int64
+		err := ctx.DB().Model(&pluginModels.QuotaPlan{}).Where("name IN ?", planNames).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(planNames)), count)
+	}, testOptions())
+}
+
+// TestQuotaServiceDefault_CreateQuotaPlan_CaseSensitive tests that name comparison is case-sensitive
+func TestQuotaServiceDefault_CreateQuotaPlan_CaseSensitive(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Create plan with specific case
+		plan1 := &pluginModels.QuotaPlan{
+			Name:        "Enterprise Plan",
+			Description: "Original enterprise plan",
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan1)
+		require.NoError(t, err)
+
+		// Try to create plan with different case - should succeed due to case-sensitivity
+		plan2 := &pluginModels.QuotaPlan{
+			Name:        "enterprise plan", // Different case
+			Description: "Different case plan",
+		}
+		err = quotaService.CreateQuotaPlan(ctx, plan2)
+		require.NoError(t, err)
+
+		// Verify both plans exist
+		var count int64
+		err = ctx.DB().Model(&pluginModels.QuotaPlan{}).Where("name IN ?", []string{"Enterprise Plan", "enterprise plan"}).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), count)
+
+		// Verify they are different plans
+		assert.NotEqual(t, plan1.ID, plan2.ID)
+	}, testOptions())
+}
+
 // TestQuotaServiceDefault_GetQuotaPlan_Success tests successful quota plan retrieval
 func TestQuotaServiceDefault_GetQuotaPlan_Success(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {


### PR DESCRIPTION
- Add GetQuotaPlanByName method to QuotaPlanManager interface
- Add ErrQuotaPlanNameExists error constant
- Implement duplicate name check in CreateQuotaPlan service method
- Return HTTP 409 Conflict when attempting to create plan with existing name
- Add comprehensive tests for GetQuotaPlanByName method
- Add unit tests for duplicate name rejection in quota service

---

<!-- kody-pr-summary:start -->
This pull request implements defensive programming to prevent the creation of quota plans with duplicate names and provides proper error handling when such conflicts occur.

**Key Changes:**

1. **Duplicate Name Prevention**: Added validation in the quota plan creation flow that checks if a plan with the same name already exists before allowing creation. If a duplicate name is detected, the system returns a specific error preventing the creation.

2. **New Query Capability**: Added `GetQuotaPlanByName` method to the `QuotaPlanManager` interface and its implementation, enabling retrieval of quota plans by their name identifier.

3. **Enhanced Error Handling**: 
   - Added new error type `ErrQuotaPlanNameExists` with user-friendly message "Quota plan with this name already exists"
   - Returns HTTP 409 Conflict status code when duplicate name attempts are detected
   - Updated admin API extension to catch and properly handle duplicate name errors with appropriate logging

4. **Case-Sensitive Validation**: The name uniqueness check is case-sensitive, allowing plans with similar but differently cased names (e.g., "Enterprise Plan" vs "enterprise plan") to coexist while preventing exact duplicates.

5. **Comprehensive Test Coverage**: Added integration and unit tests covering:
   - Successful rejection of duplicate plan names
   - Verification that only one plan exists per unique name
   - Case sensitivity behavior
   - Allowance of similar but distinct names
   - Proper error propagation through the API layer

These changes ensure data integrity by enforcing unique quota plan names while providing clear feedback to API consumers when naming conflicts occur.
<!-- kody-pr-summary:end -->