### PR TITLE
fix: handle ErrQuotaPlanNotFound in duplicate name check

### DIFF
--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -361,7 +361,7 @@ func (s *QuotaServiceDefault) CreateQuotaPlan(ctx context.Context, plan *models.
 // but we also handle UNIQUE constraint violations from the database during creation
 // to prevent race conditions (TOCTOU) where concurrent requests bypass this check.
 	existingPlan, err := s.planManager.GetQuotaPlanByName(ctx, plan.Name)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) && !errors.Is(err, models.ErrQuotaPlanNotFound) {
 		// Real database error (connection, timeout, etc.) - fail fast
 		return fmt.Errorf("failed to check for existing plan: %w", err)
 	}

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -1,6 +1,7 @@
 package quota
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	pluginModels "go.lumeweb.com/portal-plugin-quota/internal/db/models"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"gorm.io/gorm"
 )
 
 // Test constants
@@ -65,6 +67,126 @@ func TestQuotaServiceDefault_RecordUpload_Success(t *testing.T) {
 
 		err := quotaService.RecordUpload(ctx, userID, uploadID, bytes, ip)
 		require.NoError(t, err)
+	}, testOptions())
+}
+
+// TestQuotaServiceDefault_CreateQuotaPlan_WithNonExistentName tests that creating a plan
+// with a name that doesn't exist in the database (the common case) should succeed.
+//
+// This test replicates the bug scenario reported:
+// - A new quota plan is being created with name "Enterprise Plan"
+// - The duplicate name check calls GetQuotaPlanByName("Enterprise Plan")
+// - GetQuotaPlanByName returns ErrQuotaPlanNotFound (plan doesn't exist - expected state)
+// - The CreateQuotaPlan should NOT fail with "failed to check for existing plan"
+// - It should proceed to create the plan successfully
+//
+// Bug: The CreateQuotaPlan implementation in fix/duplicate-quota-plan-name-error-handling
+// incorrectly treats ErrQuotaPlanNotFound as an actual error instead of the expected
+// "plan doesn't exist" state, causing create to fail.
+func TestQuotaServiceDefault_CreateQuotaPlan_WithNonExistentName(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Mock the plan manager to simulate what happens when checking for a plan name
+		// that doesn't exist
+		mockPlanManager := pluginCore.NewMockQuotaPlanManager(tb)
+		quotaService.(*QuotaServiceDefault).planManager = mockPlanManager
+
+		// Setup: GetQuotaPlanByName returns ErrQuotaPlanNotFound because the plan
+		// doesn't exist yet (this is the expected state when creating a new plan)
+		mockPlanManager.EXPECT().
+			GetQuotaPlanByName(mock.Anything, "Enterprise Plan").
+			Return(nil, pluginModels.ErrQuotaPlanNotFound)
+
+		// Act: Create the plan
+		plan := &pluginModels.QuotaPlan{
+			Name:        "Enterprise Plan",
+			Description: "Enterprise tier quota plan",
+		}
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+
+		// Assert: Creation should succeed, not fail with "failed to check for existing plan"
+		// The error message "failed to create quota plan: failed to check for existing plan: quota plan not found: Enterprise Plan"
+		// indicates the implementation incorrectly treats the "not found" error as an actual error
+
+		// This assert will fail with the buggy behavior:
+		// Error: "failed to create quota plan: failed to check for existing plan: quota plan not found: Enterprise Plan"
+		require.NoError(t, err, "Creating plan with non-existent name should succeed")
+
+		// Verify plan was actually created in the database
+		require.NotZero(t, plan.ID, "Plan should have been assigned an ID")
+
+		// Verify we can retrieve it back
+		retrieved, err := quotaService.GetQuotaPlan(ctx, plan.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Enterprise Plan", retrieved.Name)
+		assert.Equal(t, "Enterprise tier quota plan", retrieved.Description)
+	}, testOptions())
+}
+
+// TestQuotaServiceDefault_CreateQuotaPlan_WithExistingName tests that creating a plan
+// with a name that already exists returns a conflict error.
+func TestQuotaServiceDefault_CreateQuotaPlan_WithExistingName(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Mock the plan manager to simulate what happens when checking for a plan name
+		// that already exists
+		mockPlanManager := pluginCore.NewMockQuotaPlanManager(tb)
+		quotaService.(*QuotaServiceDefault).planManager = mockPlanManager
+
+		// Setup: GetQuotaPlanByName returns an existing plan (name is taken)
+		existingPlan := &pluginModels.QuotaPlan{
+			Model: gorm.Model{ID: 1},
+			Name:  "Enterprise Plan",
+		}
+		mockPlanManager.EXPECT().
+			GetQuotaPlanByName(mock.Anything, "Enterprise Plan").
+			Return(existingPlan, nil)
+
+		// Act: Try to create a plan with the same name
+		plan := &pluginModels.QuotaPlan{
+			Name:        "Enterprise Plan",
+			Description: "Another Enterprise tier quota plan",
+		}
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+
+		// Assert: Should get name conflict error
+		require.Error(t, err)
+		require.ErrorIs(t, err, pluginModels.ErrQuotaPlanNameExists)
+	}, testOptions())
+}
+
+// TestQuotaServiceDefault_CreateQuotaPlan_WithDatabaseError tests that actual database errors
+// during the duplicate check are properly propagated.
+func TestQuotaServiceDefault_CreateQuotaPlan_WithDatabaseError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE)
+
+		// Mock the plan manager to simulate a database error
+		mockPlanManager := pluginCore.NewMockQuotaPlanManager(tb)
+		quotaService.(*QuotaServiceDefault).planManager = mockPlanManager
+
+		// Setup: GetQuotaPlanByName returns a database error (e.g., connection issue)
+		dbError := errors.New("database connection failed")
+		mockPlanManager.EXPECT().
+			GetQuotaPlanByName(mock.Anything, "Enterprise Plan").
+			Return(nil, dbError)
+
+		// Act: Try to create a plan
+		plan := &pluginModels.QuotaPlan{
+			Name:        "Enterprise Plan",
+			Description: "Enterprise tier quota plan",
+		}
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+
+		// Assert: The database error should be wrapped and propagated
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check for existing plan")
+		assert.Contains(t, err.Error(), "database connection failed")
 	}, testOptions())
 }
 
@@ -481,7 +603,7 @@ func TestQuotaServiceDefault_GetSystemStats_Success(t *testing.T) {
 
 		// Act
 		stats, err := quotaService.GetSystemStats(ctx)
-		
+
 		// Assert
 		require.NoError(t, err)
 		assert.NotNil(t, stats)


### PR DESCRIPTION
- Add check for models.ErrQuotaPlanNotFound in addition to gorm.ErrRecordNotFound
- GetQuotaPlanByName wraps ErrRecordNotFound into ErrQuotaPlanNotFound
- This prevents 'quota plan not found' from being treated as an actual error
- Allows plan creation to proceed when checking for non-existent plan names

---

<!-- kody-pr-summary:start -->
Fixes a bug in the quota plan creation process where checking for duplicate plan names would incorrectly fail when the plan name doesn't exist yet.

**Problem:**
When creating a new quota plan, the system checks if a plan with the same name already exists. The `GetQuotaPlanByName` method returns `ErrQuotaPlanNotFound` when a plan doesn't exist, but the duplicate name validation logic only handled `gorm.ErrRecordNotFound`. This caused plan creation to fail with a "failed to check for existing plan" error for new, unique plan names.

**Solution:**
Updated the error handling in `CreateQuotaPlan` to treat both `gorm.ErrRecordNotFound` and `models.ErrQuotaPlanNotFound` as expected "not found" conditions (indicating the name is available), while still properly propagating actual database errors.

**Changes:**
- Modified the duplicate name check to recognize `ErrQuotaPlanNotFound` as a valid "plan doesn't exist" state
- Added comprehensive test coverage for:
  - Creating plans with non-existent names (the bug scenario)
  - Creating plans with existing names (conflict detection)
  - Database error handling during duplicate checks
<!-- kody-pr-summary:end -->