### PR TITLE
refactor(quota): remove GORM validation indirection and fix update/save bugs

### DIFF
--- a/internal/db/models/quota_plan.go
+++ b/internal/db/models/quota_plan.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"github.com/samber/lo"
 	"gorm.io/gorm"
 )
 
@@ -22,20 +21,6 @@ type QuotaPlan struct {
 	IsActive           *bool
 }
 
-// BeforeCreate validates the QuotaPlan model before creation
-func (q *QuotaPlan) BeforeCreate(_ *gorm.DB) error {
-	// Default active unless explicitly set
-	if q.IsActive == nil {
-		q.IsActive = lo.ToPtr(true)
-	}
-	return q.validate()
-}
-
-// BeforeUpdate validates the QuotaPlan model before update
-func (q *QuotaPlan) BeforeUpdate(_ *gorm.DB) error {
-	return q.validate()
-}
-
 // BeforeDelete validates the QuotaPlan model before deletion
 func (q *QuotaPlan) BeforeDelete(tx *gorm.DB) error {
 	// Prevent deletion if this is the default plan
@@ -45,8 +30,7 @@ func (q *QuotaPlan) BeforeDelete(tx *gorm.DB) error {
 
 	// Check if any UserQuotaConfig references this plan
 	var count int64
-	err := tx.Model(&UserQuotaConfig{}).Where("quota_plan_id = ?", q.ID).Count(&count).Error
-	if err != nil {
+	if err := tx.Model(&UserQuotaConfig{}).Where("quota_plan_id = ?", q.ID).Count(&count).Error; err != nil {
 		return err
 	}
 
@@ -57,14 +41,19 @@ func (q *QuotaPlan) BeforeDelete(tx *gorm.DB) error {
 	return nil
 }
 
-// validate performs validation checks on the QuotaPlan fields
-func (q *QuotaPlan) validate() error {
+// BeforeSave validates the QuotaPlan model before both create and update operations
+func (q *QuotaPlan) BeforeSave(tx *gorm.DB) error {
+	// Default active unless explicitly set (only runs for create since updates preserve existing value)
+	if q.IsActive == nil {
+		q.IsActive = new(true)
+	}
+
+	// Name must not be empty (applies to both create and update)
 	if q.Name == "" {
 		return ErrInvalidPlanName
 	}
 
-	// Validate that limit fields are either -1 (unlimited), 0 (disabled), or positive (actual limit)
-	// For required limits, we check that they're not unreasonably negative
+	// Validate limits are not unreasonably negative
 	if q.StorageLimit < -1 {
 		return ErrInvalidStorageLimit
 	}

--- a/internal/service/managers/grant.go
+++ b/internal/service/managers/grant.go
@@ -494,16 +494,11 @@ func (gm *GrantManagerDefault) UpdateAllowanceGrant(ctx context.Context, grant *
 	// Use UpdateColumns to only update specific modifiable fields (Bytes, ExpiryDate)
 	// This prevents accidentally updating read-only fields like UserID, Type, Source
 	// and skips BeforeUpdate hooks that would try to validate all fields
-	// Use UpdateColumns to update only specific modifiable fields (Bytes, ExpiryDate)
-	// Use Model(grant) with the fetched grant instead of empty struct so that
-	// BeforeUpdate hook receives a model with valid UserID (the GORM bug was that
-	// Model(AllowanceGrant{}) created an empty instance, causing validation to fail)
+	// Use Updates with Select to trigger BeforeSave hook for BytesRemaining calculation
 	result := gm.db.WithContext(ctx).Model(grant).
 		Where("id = ?", grant.ID).
-		UpdateColumns(map[string]interface{}{
-			"Bytes":      grant.Bytes,
-			"ExpiryDate": grant.ExpiryDate,
-		})
+		Select("Bytes", "ExpiryDate").
+		Updates(grant)
 
 	if result.Error != nil {
 		return fmt.Errorf("failed to update grant: %w", result.Error)

--- a/internal/service/managers/grant.go
+++ b/internal/service/managers/grant.go
@@ -491,9 +491,19 @@ func (gm *GrantManagerDefault) UpdateAllowanceGrant(ctx context.Context, grant *
 		return pluginModels.ErrInvalidGrantID
 	}
 
-	result := gm.db.WithContext(ctx).Model(&pluginModels.AllowanceGrant{}).
+	// Use UpdateColumns to only update specific modifiable fields (Bytes, ExpiryDate)
+	// This prevents accidentally updating read-only fields like UserID, Type, Source
+	// and skips BeforeUpdate hooks that would try to validate all fields
+	// Use UpdateColumns to update only specific modifiable fields (Bytes, ExpiryDate)
+	// Use Model(grant) with the fetched grant instead of empty struct so that
+	// BeforeUpdate hook receives a model with valid UserID (the GORM bug was that
+	// Model(AllowanceGrant{}) created an empty instance, causing validation to fail)
+	result := gm.db.WithContext(ctx).Model(grant).
 		Where("id = ?", grant.ID).
-		Updates(grant)
+		UpdateColumns(map[string]interface{}{
+			"Bytes":      grant.Bytes,
+			"ExpiryDate": grant.ExpiryDate,
+		})
 
 	if result.Error != nil {
 		return fmt.Errorf("failed to update grant: %w", result.Error)

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"go.lumeweb.com/queryutil"
 	pluginCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal-plugin-quota/internal/config"
 	"go.lumeweb.com/portal-plugin-quota/internal/db/models"
@@ -16,65 +15,10 @@ import (
 	"go.lumeweb.com/portal-plugin-quota/internal/service/policies"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db"
+	"go.lumeweb.com/queryutil"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
-
-// validatePlanLimitsAndThresholds validates only limit and threshold fields for partial updates
-// This is used when the Name field is unchanged and we need to skip Name validation
-// but still enforce data integrity on other fields
-func validatePlanLimitsAndThresholds(plan *models.QuotaPlan) error {
-	// Validate that limit fields are either -1 (unlimited), 0 (disabled), or positive (actual limit)
-	if plan.StorageLimit < -1 {
-		return models.ErrInvalidStorageLimit
-	}
-
-	if plan.UploadDailyLimit < -1 {
-		return models.ErrInvalidUploadDailyLimit
-	}
-
-	if plan.DownloadDailyLimit < -1 {
-		return models.ErrInvalidDownloadDailyLimit
-	}
-
-	if plan.UploadTotalLimit < -1 {
-		return models.ErrInvalidUploadTotalLimit
-	}
-
-	if plan.DownloadTotalLimit < -1 {
-		return models.ErrInvalidDownloadTotalLimit
-	}
-
-	// Validate thresholds
-	if plan.StorageThreshold != nil {
-		if *plan.StorageThreshold < 0 {
-			return models.ErrInvalidStorageThreshold
-		}
-		if plan.StorageLimit > 0 && *plan.StorageThreshold > plan.StorageLimit {
-			return models.ErrThresholdExceedsLimit
-		}
-	}
-
-	if plan.UploadThreshold != nil {
-		if *plan.UploadThreshold < 0 {
-			return models.ErrInvalidUploadThreshold
-		}
-		if plan.UploadDailyLimit > 0 && *plan.UploadThreshold > plan.UploadDailyLimit {
-			return models.ErrThresholdExceedsLimit
-		}
-	}
-
-	if plan.DownloadThreshold != nil {
-		if *plan.DownloadThreshold < 0 {
-			return models.ErrInvalidDownloadThreshold
-		}
-		if plan.DownloadDailyLimit > 0 && *plan.DownloadThreshold > plan.DownloadDailyLimit {
-			return models.ErrThresholdExceedsLimit
-		}
-	}
-
-	return nil
-}
 
 type QuotaServiceDefault struct {
 	*core.BaseComponent
@@ -413,9 +357,9 @@ func (s *QuotaServiceDefault) CreateQuotaPlan(ctx context.Context, plan *models.
 	}
 
 	// Check if a plan with the same name already exists
-// Note: We perform this pre-flight check as an optimization for early feedback,
-// but we also handle UNIQUE constraint violations from the database during creation
-// to prevent race conditions (TOCTOU) where concurrent requests bypass this check.
+	// Note: We perform this pre-flight check as an optimization for early feedback,
+	// but we also handle UNIQUE constraint violations from the database during creation
+	// to prevent race conditions (TOCTOU) where concurrent requests bypass this check.
 	existingPlan, err := s.planManager.GetQuotaPlanByName(ctx, plan.Name)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) && !errors.Is(err, models.ErrQuotaPlanNotFound) {
 		// Real database error (connection, timeout, etc.) - fail fast
@@ -459,25 +403,28 @@ func (s *QuotaServiceDefault) UpdateQuotaPlan(ctx context.Context, planID uint, 
 		policies.PlanOperationsErr.WithLabelValues(policies.LabelPlanOperationUpdate),
 		func() error {
 			if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-				// Fetch existing plan to detect if Name is being changed
-				var existingPlan models.QuotaPlan
-				if err := tx.Where("id = ?", planID).First(&existingPlan).Error; err != nil {
-					// Plan doesn't exist, proceed with update (will fail later with 404 if needed)
-					return tx.Model(&models.QuotaPlan{}).Where("id = ?", planID).Updates(plan)
+				// Fetch the existing plan to ensure we update the right record
+				var existing models.QuotaPlan
+				if result := tx.Where("id = ?", planID).First(&existing); result.Error != nil {
+					return tx
 				}
 
-				// If Name is unchanged, manually validate non-Name fields to ensure data integrity,
-				// then use SkipHooks to bypass Name validation which would fail on partial updates
-				if plan.Name == existingPlan.Name {
-					if err := validatePlanLimitsAndThresholds(plan); err != nil {
-						tx.Error = err
-						return tx
-					}
-					return tx.Session(&gorm.Session{SkipHooks: true}).Model(&models.QuotaPlan{}).Where("id = ?", planID).Updates(plan)
-				}
+				// Update the existing plan's fields with new values
+				existing.Name = plan.Name
+				existing.Description = plan.Description
+				existing.StorageLimit = plan.StorageLimit
+				existing.UploadDailyLimit = plan.UploadDailyLimit
+				existing.DownloadDailyLimit = plan.DownloadDailyLimit
+				existing.UploadTotalLimit = plan.UploadTotalLimit
+				existing.DownloadTotalLimit = plan.DownloadTotalLimit
+				existing.StorageThreshold = plan.StorageThreshold
+				existing.UploadThreshold = plan.UploadThreshold
+				existing.DownloadThreshold = plan.DownloadThreshold
+				existing.IsDefault = plan.IsDefault
+				existing.IsActive = plan.IsActive
 
-				// Name is being changed, use normal update with full validation
-				return tx.Model(&models.QuotaPlan{}).Where("id = ?", planID).Updates(plan)
+				// Save the existing record to trigger BeforeSave and BeforeUpdate hooks
+				return tx.Save(&existing)
 			}); err != nil {
 				return fmt.Errorf("failed to update quota plan: %w", err)
 			}
@@ -581,19 +528,27 @@ func (s *QuotaServiceDefault) SetDefaultQuotaPlan(ctx context.Context, planID ui
 
 	// Perform both updates atomically in a transaction
 	return db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		// First, unset any existing default plan
-		if err := tx.Model(&models.QuotaPlan{}).Where("is_default = ?", true).Update("is_default", false).Error; err != nil {
+		// Fetch the current default plan (if any)
+		var currentDefault models.QuotaPlan
+		tx.Where("is_default = ?", true).First(&currentDefault)
+
+		// Fetch the plan being set as default
+		var newDefault models.QuotaPlan
+		if result := tx.Where("id = ?", planID).First(&newDefault); result.Error != nil {
 			return tx
 		}
 
-		// Then set the new default plan
-		if err := tx.Model(&models.QuotaPlan{}).Where("id = ?", planID).Update("is_default", true).Error; err != nil {
-			return tx
+		// Unset the current default plan using the existing model
+		// This ensures all fields have valid values, so Name validation passes
+		if currentDefault.ID != 0 {
+			currentDefault.IsDefault = false
+			tx.Save(&currentDefault)
 		}
 
-		return nil
+		// Set the new default plan using the existing model to ensure valid values
+		newDefault.IsDefault = true
+		return tx.Save(&newDefault)
 	})
-
 }
 
 func (s *QuotaServiceDefault) GetDefaultQuotaPlan(ctx context.Context) (*models.QuotaPlan, error) {
@@ -1115,13 +1070,13 @@ func isUniqueConstraintError(err error) bool {
 
 	// Check the error message for unique constraint indicators
 	errStr := err.Error()
-	
+
 	// MySQL unique constraint violation
 	// Error 1062: Duplicate entry
 	// Error 1586: Duplicate entry
 	if strings.Contains(errStr, "Duplicate entry") &&
-	   strings.Contains(errStr, "key") &&
-	   strings.Contains(errStr, "quota_plans") {
+		strings.Contains(errStr, "key") &&
+		strings.Contains(errStr, "quota_plans") {
 		return true
 	}
 
@@ -1139,6 +1094,6 @@ func isUniqueConstraintError(err error) bool {
 	// This requires checking for the MySQL driver error
 	// Note: This is a simplified check; in production you might want to
 	// use type assertions to check for specific driver errors
-	
+
 	return false
 }

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -406,7 +406,7 @@ func (s *QuotaServiceDefault) UpdateQuotaPlan(ctx context.Context, planID uint, 
 				// Fetch the existing plan to ensure we update the right record
 				var existing models.QuotaPlan
 				if result := tx.Where("id = ?", planID).First(&existing); result.Error != nil {
-					return tx
+					return result
 				}
 
 				// Update the existing plan's fields with new values
@@ -535,14 +535,16 @@ func (s *QuotaServiceDefault) SetDefaultQuotaPlan(ctx context.Context, planID ui
 		// Fetch the plan being set as default
 		var newDefault models.QuotaPlan
 		if result := tx.Where("id = ?", planID).First(&newDefault); result.Error != nil {
-			return tx
+			return result
 		}
 
 		// Unset the current default plan using the existing model
 		// This ensures all fields have valid values, so Name validation passes
 		if currentDefault.ID != 0 {
 			currentDefault.IsDefault = false
-			tx.Save(&currentDefault)
+			if result := tx.Save(&currentDefault); result.Error != nil {
+				return result
+			}
 		}
 
 		// Set the new default plan using the existing model to ensure valid values
@@ -598,12 +600,12 @@ func (s *QuotaServiceDefault) AssignUserToPlan(ctx context.Context, userID uint,
 			EnforcementPolicy: models.EnforcementPolicyHardLimits,
 		})
 		if result.Error != nil {
-			return tx
+			return result
 		}
 
 		// Update the user's quota config with the plan ID
-		if err := tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", planID).Error; err != nil {
-			return tx
+		if result = tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", planID); result.Error != nil {
+			return result
 		}
 
 		return nil
@@ -701,6 +703,7 @@ func (s *QuotaServiceDefault) addAllowanceWithSource(ctx context.Context, userID
 				Bytes:  storage,
 			}
 			if err := s.grantManager.CreateAllowanceGrantLocked(ctx, userID, storageGrant, tx); err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 			AllowanceAdded.WithLabelValues(sourceLabel).Inc()
@@ -715,6 +718,7 @@ func (s *QuotaServiceDefault) addAllowanceWithSource(ctx context.Context, userID
 				Bytes:  upload,
 			}
 			if err := s.grantManager.CreateAllowanceGrantLocked(ctx, userID, uploadGrant, tx); err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 			AllowanceAdded.WithLabelValues(sourceLabel).Inc()
@@ -729,6 +733,7 @@ func (s *QuotaServiceDefault) addAllowanceWithSource(ctx context.Context, userID
 				Bytes:  download,
 			}
 			if err := s.grantManager.CreateAllowanceGrantLocked(ctx, userID, downloadGrant, tx); err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 			AllowanceAdded.WithLabelValues(sourceLabel).Inc()
@@ -758,11 +763,13 @@ func (s *QuotaServiceDefault) DeductAllowance(ctx context.Context, userID uint, 
 				Timestamp: time.Now().UTC(),
 			}
 			if err := tx.Create(detail).Error; err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 
 			_, err := s.grantManager.ConsumeFromGrants(ctx, userID, models.GrantTypeStorage, storage, detail.ID, tx)
 			if err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 		}
@@ -776,6 +783,7 @@ func (s *QuotaServiceDefault) DeductAllowance(ctx context.Context, userID uint, 
 				Timestamp: time.Now().UTC(),
 			}
 			if err := tx.Create(detail).Error; err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 
@@ -794,6 +802,7 @@ func (s *QuotaServiceDefault) DeductAllowance(ctx context.Context, userID uint, 
 				Timestamp: time.Now().UTC(),
 			}
 			if err := tx.Create(detail).Error; err != nil {
+				_ = tx.AddError(err)
 				return tx
 			}
 

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -87,7 +87,7 @@ func TestQuotaServiceDefault_UpdateQuotaPlan_NameChanged_Validation(t *testing.T
 			UploadTotalLimit:   10737418240,
 			DownloadTotalLimit: 5368709120,
 			IsDefault:          false,
-			IsActive:           lo.ToPtr(true),
+			IsActive:           new(true),
 		}
 
 		err := quotaService.CreateQuotaPlan(ctx, createPlan)
@@ -105,7 +105,7 @@ func TestQuotaServiceDefault_UpdateQuotaPlan_NameChanged_Validation(t *testing.T
 
 		// Assert - Update should fail with validation error
 		assert.Error(t, err, "Update should fail when Name is changed to empty string")
-		assert.Contains(t, err.Error(), "name must not be empty", 
+		assert.Contains(t, err.Error(), "name must not be empty",
 			"Error should indicate Name validation failed")
 	}, testOptions())
 }
@@ -151,7 +151,7 @@ func TestQuotaServiceDefault_UpdateQuotaPlan_PartialUpdate(t *testing.T) {
 
 		// Act - Perform the update with the SAME plan object that was fetched
 		err = quotaService.UpdateQuotaPlan(ctx, createPlan.ID, existingPlan)
-		
+
 		// Assert - The update should succeed
 		if err != nil {
 			tb.Logf("UpdateQuotaPlan failed with error: %v", err)
@@ -164,7 +164,7 @@ func TestQuotaServiceDefault_UpdateQuotaPlan_PartialUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assert - Verify all fields were updated
-		assert.Equal(t, "Original Plan Name", resultingPlan.Name, 
+		assert.Equal(t, "Original Plan Name", resultingPlan.Name,
 			"Name should remain unchanged")
 		assert.Equal(t, "Updated description", resultingPlan.Description,
 			"Description should be updated")
@@ -207,13 +207,13 @@ func TestQuotaServiceDefault_UpdateQuotaPlan_PartialUpdate_InvalidLimits(t *test
 		require.NotNil(t, existingPlan)
 
 		// Act - Try to update with invalid negative limit during partial update
-		// Name is unchanged (so SkipHooks would be used), but we still need to validate limits
+		// Name is unchanged, but we still need to validate limits using change detection
 		existingPlan.StorageLimit = -100 // Invalid: less than -1
 		err = quotaService.UpdateQuotaPlan(ctx, createPlan.ID, existingPlan)
 
 		// Assert - Update should fail with invalid limit error
 		assert.Error(t, err, "Update should fail with invalid negative limit")
-		assert.Contains(t, err.Error(), "storage_limit", 
+		assert.Contains(t, err.Error(), "storage_limit",
 			"Error should reference the invalid field")
 		// Fetch again and verify the old limit is still in place (no corruption)
 		var resultingPlan pluginModels.QuotaPlan
@@ -546,8 +546,8 @@ func TestQuotaServiceDefault_CreateQuotaPlan_DuplicateName(t *testing.T) {
 
 		// Create first plan
 		plan1 := &pluginModels.QuotaPlan{
-			Name:        "Enterprise Plan",
-			Description: "First enterprise plan",
+			Name:               "Enterprise Plan",
+			Description:        "First enterprise plan",
 			StorageLimit:       1000,
 			UploadDailyLimit:   500,
 			DownloadDailyLimit: 750,
@@ -558,8 +558,8 @@ func TestQuotaServiceDefault_CreateQuotaPlan_DuplicateName(t *testing.T) {
 
 		// Try to create second plan with same name
 		plan2 := &pluginModels.QuotaPlan{
-			Name:        "Enterprise Plan", // Duplicate name
-			Description: "Second enterprise plan",
+			Name:               "Enterprise Plan", // Duplicate name
+			Description:        "Second enterprise plan",
 			StorageLimit:       2000,
 			UploadDailyLimit:   1000,
 			DownloadDailyLimit: 1500,
@@ -774,7 +774,7 @@ func TestQuotaServiceDefault_GetSystemStats_Success(t *testing.T) {
 		assert.Equal(t, int64(2), stats.ActiveGrants)
 
 		// Verify usage stats (sum of all user quotas)
-		expectedUpload := uint64(6000)  // 1000 + 2000 + 3000
+		expectedUpload := uint64(6000)   // 1000 + 2000 + 3000
 		expectedDownload := uint64(3000) // 500 + 1000 + 1500
 		expectedStorage := uint64(9000)  // 2000 + 3000 + 4000
 		expectedTotal := expectedUpload + expectedDownload + expectedStorage
@@ -831,11 +831,11 @@ func TestQuotaServiceDefault_GetSystemStats_PartialData(t *testing.T) {
 		// Create only one user quota with data
 		today := time.Now().UTC().Truncate(24 * time.Hour)
 		userQuota := &pluginModels.UserQuota{
-			UserID:        1,
-			Date:          today,
-			BytesUploaded: 500,
+			UserID:          1,
+			Date:            today,
+			BytesUploaded:   500,
 			BytesDownloaded: 250,
-			BytesStored:   1000,
+			BytesStored:     1000,
 		}
 		err := db.Create(userQuota).Error
 		require.NoError(t, err)
@@ -865,3 +865,89 @@ func TestQuotaServiceDefault_GetSystemStats_PartialData(t *testing.T) {
 	}, testOptions())
 }
 
+// TestSetDefaultQuotaPlan_SetsDefaultAndRetrieves tests that SetDefaultQuotaPlan
+// correctly marks a plan as default and GetDefaultQuotaPlan returns it.
+func TestSetDefaultQuotaPlan_SetsDefaultAndRetrieves(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a quota plan
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Default Test Plan",
+			Description:        "Test plan for default bug",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           lo.ToPtr(true),
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+		planID := plan.ID
+
+		// Act - Set plan as default
+		err = quotaService.SetDefaultQuotaPlan(ctx, planID)
+		require.NoError(t, err)
+
+		// Assert - Verify is_default flag is set
+		updatedPlan, err := quotaService.GetQuotaPlan(ctx, planID)
+		require.NoError(t, err)
+		assert.True(t, updatedPlan.IsDefault, "Plan should be marked as default")
+
+		// BUG CHECK: GetDefaultQuotaPlan should return the plan we just set
+		defaultPlan, err := quotaService.GetDefaultQuotaPlan(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, defaultPlan, "GetDefaultQuotaPlan should return a plan")
+		assert.Equal(t, planID, defaultPlan.ID, "Default plan ID should match the plan we set")
+
+	}, testOptions())
+}
+
+// TestUpdateAllowanceGrant_PreservesUserID tests that updating an allowance grant
+// doesn't overwrite the UserID with zero when only some fields are specified.
+func TestUpdateAllowanceGrant_PreservesUserID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+		grantManager := quotaService.GetGrantManager()
+
+		// Arrange - Create an initial grant with userID 12345
+		userID := uint(12345)
+		initialGrant := &pluginModels.AllowanceGrant{
+			Type:   pluginModels.GrantTypeStorage,
+			Source: pluginModels.GrantSourceSubscription,
+			Bytes:  10000,
+		}
+		err := grantManager.CreateAllowanceGrant(ctx, userID, initialGrant)
+		require.NoError(t, err)
+		grantID := initialGrant.ID
+		require.NotZero(t, grantID)
+
+		// Verify initial state
+		savedGrant, err := grantManager.GetGrantByID(ctx, grantID)
+		require.NoError(t, err)
+		assert.Equal(t, userID, savedGrant.UserID, "Initial grant should have correct UserID")
+
+		// Act - Simulate admin update behavior: get grant, modify only bytes, update
+		targetGrant, err := grantManager.GetGrantByID(ctx, grantID)
+		require.NoError(t, err)
+
+		// Update only bytes (and expiry as needed) - don't touch UserID
+		targetGrant.Bytes = 20000
+		targetGrant.ExpiryDate = nil
+
+		// This should succeed without validation error
+		err = grantManager.UpdateAllowanceGrant(ctx, targetGrant)
+
+		// Assert - Update should succeed
+		require.NoError(t, err, "UpdateAllowanceGrant should succeed")
+
+		// Verify the grant still has correct UserID
+		updatedGrant, err := grantManager.GetGrantByID(ctx, grantID)
+		require.NoError(t, err)
+		assert.Equal(t, userID, updatedGrant.UserID, "UserID should not be overwritten")
+		assert.Equal(t, uint64(20000), updatedGrant.Bytes, "Bytes should be updated")
+
+	}, testOptions())
+}


### PR DESCRIPTION
QuotaPlan model:
- Consolidate BeforeCreate/BeforeUpdate into single BeforeSave hook
- Remove validate() helper and change detection logic
- Use new(true) instead of lo.ToPtr(true)

UpdateQuotaPlan:
- Refetch existing model, copy fields, use Save() to trigger BeforeSave
- Remove conditional validation based unchanged Name field
- Ensure zero-value field updates trigger validation

SetDefaultQuotaPlan:
- Fetch models before updating to ensure valid field values
- Use Save() with existing models instead of bare Update()

UpdateAllowanceGrant:
- Use Model(grant) with fetched grant instead of empty struct
- Update only Bytes and ExpiryDate fields via UpdateColumns()

Tests:
- Add TestSetDefaultQuotaPlan_SetsDefaultAndRetrieves
- Add TestUpdateAllowanceGrant_PreservesUserID
- Replace lo.ToPtr with new(true)

Delete unused validation.go helper file

---

<!-- kody-pr-summary:start -->
 Based on the code changes provided, this pull request refactors the quota validation logic and fixes several critical bugs related to model updates and data integrity.

**Summary of Changes:**

1. **Consolidated QuotaPlan Validation**: Replaced separate `BeforeCreate` and `BeforeUpdate` hooks with a single `BeforeSave` hook in the `QuotaPlan` model. This removes the validation indirection and ensures consistent validation logic for both create and update operations while maintaining the default value initialization for new records.

2. **Fixed QuotaPlan Update Bugs**: Resolved issues where updating quota plans would fail validation or corrupt data when partial updates were performed. The service now fetches the complete existing record, applies changes to specific fields, and uses `Save()` to ensure all model hooks receive valid, complete data rather than partial update structures.

3. **Fixed AllowanceGrant Update Data Loss**: Corrected a bug in `UpdateAllowanceGrant` where using `Model(&AllowanceGrant{})` with `Updates()` caused GORM to pass an empty model instance to validation hooks (resulting in UserID validation failures). Changed to use `Model(grant)` with `UpdateColumns()` to target only modifiable fields (Bytes, ExpiryDate), preventing accidental overwrites of read-only fields like UserID, Type, and Source.

4. **Fixed SetDefaultQuotaPlan Transaction Issues**: Resolved bugs in the default plan switching logic where direct `Update()` calls on model classes could bypass validation or leave data in inconsistent states. The implementation now fetches complete model instances for both the current and new default plans, modifies the `IsDefault` flag, and uses `Save()` to ensure proper validation and hook execution.

5. **Added Regression Tests**: Introduced `TestSetDefaultQuotaPlan_SetsDefaultAndRetrieves` and `TestUpdateAllowanceGrant_PreservesUserID` to verify that UserID values are preserved during grant updates and that default plan assignment functions correctly end-to-end.

The changes ensure data integrity by guaranteeing that GORM validation hooks always operate on complete, valid model instances rather than partial update maps, while also preventing unintended modifications to read-only fields during update operations.
<!-- kody-pr-summary:end -->