### PR TITLE
fix: resolve nil pointer dereference in UsageAggregator initialization

### DIFF
--- a/core/mock_UsageManager.go
+++ b/core/mock_UsageManager.go
@@ -40,6 +40,78 @@ func (_m *MockUsageManager) EXPECT() *MockUsageManager_Expecter {
 	return &MockUsageManager_Expecter{mock: &_m.Mock}
 }
 
+// GetAggregatedUsageByType provides a mock function for the type MockUsageManager
+func (_mock *MockUsageManager) GetAggregatedUsageByType(ctx context.Context, userID uint, usageType UsageType) (uint64, error) {
+	ret := _mock.Called(ctx, userID, usageType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAggregatedUsageByType")
+	}
+
+	var r0 uint64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, UsageType) (uint64, error)); ok {
+		return returnFunc(ctx, userID, usageType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, UsageType) uint64); ok {
+		r0 = returnFunc(ctx, userID, usageType)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, UsageType) error); ok {
+		r1 = returnFunc(ctx, userID, usageType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUsageManager_GetAggregatedUsageByType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAggregatedUsageByType'
+type MockUsageManager_GetAggregatedUsageByType_Call struct {
+	*mock.Call
+}
+
+// GetAggregatedUsageByType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+//   - usageType UsageType
+func (_e *MockUsageManager_Expecter) GetAggregatedUsageByType(ctx interface{}, userID interface{}, usageType interface{}) *MockUsageManager_GetAggregatedUsageByType_Call {
+	return &MockUsageManager_GetAggregatedUsageByType_Call{Call: _e.mock.On("GetAggregatedUsageByType", ctx, userID, usageType)}
+}
+
+func (_c *MockUsageManager_GetAggregatedUsageByType_Call) Run(run func(ctx context.Context, userID uint, usageType UsageType)) *MockUsageManager_GetAggregatedUsageByType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 UsageType
+		if args[2] != nil {
+			arg2 = args[2].(UsageType)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsageManager_GetAggregatedUsageByType_Call) Return(v uint64, err error) *MockUsageManager_GetAggregatedUsageByType_Call {
+	_c.Call.Return(v, err)
+	return _c
+}
+
+func (_c *MockUsageManager_GetAggregatedUsageByType_Call) RunAndReturn(run func(ctx context.Context, userID uint, usageType UsageType) (uint64, error)) *MockUsageManager_GetAggregatedUsageByType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetCurrentUsage provides a mock function for the type MockUsageManager
 func (_mock *MockUsageManager) GetCurrentUsage(ctx context.Context, userID uint) (*Usage, error) {
 	ret := _mock.Called(ctx, userID)

--- a/core/usage.go
+++ b/core/usage.go
@@ -51,6 +51,9 @@ type UsageManager interface {
 	// RecordUsageAndConsume records a usage detail and consumes from grants in a single transaction
 	// This is used by allowance policy enforcers to atomically record usage and consume allowance
 	RecordUsageAndConsume(ctx context.Context, detail *models.UserUsageDetail, grantType models.GrantType, bytes uint64) error
+
+	// GetAggregatedUsageByType returns the aggregated usage for a specific user and usage type
+	GetAggregatedUsageByType(ctx context.Context, userID uint, usageType UsageType) (uint64, error)
 }
 
 // UsageAggregator defines the interface for aggregating usage data

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -50,6 +50,9 @@ func NewQuotaService() (core.Service, []core.ContextBuilderOption, error) {
 			service.usageManager = managers.NewUsageManager(ctx)
 			service.grantManager = managers.NewGrantManager(ctx)
 
+			// Initialize usage aggregator (usageManager implements UsageAggregator interface)
+			service.usageAggregator = service.usageManager
+
 			// Initialize limit resolver
 			service.limitResolver = policies.NewLimitResolver(ctx, service)
 


### PR DESCRIPTION
Root Cause:
- The QuotaServiceDefault.usageAggregator field was never initialized in NewQuotaService()
- This caused a nil pointer dereference when GetUsageAggregator() was called
- Crash occurred at hard_limits.go:90 during cron job quota checking

Changes:
- Added GetAggregatedUsageByType to UsageManager interface (method already existed on concrete UsageManager)
- Initialized service.usageAggregator = service.usageManager in NewQuotaService()
- Regenerated mocks to include new method

The fix ensures UsageManager (which implements UsageAggregator) is properly initialized and available for policy enforcement when checking total upload/download limits with aggregated usage.

---

<!-- kody-pr-summary:start -->
 **Summary:**
Fixes a nil pointer dereference issue in the quota service by properly initializing the `UsageAggregator` interface. Additionally extends the `UsageManager` interface with a new method for retrieving aggregated usage by specific type and updates the corresponding mock implementation.

**Changes:**

1. **Fixed nil pointer dereference in quota service initialization** (`internal/service/quota/quota.go`):
   - Added explicit initialization of `usageAggregator` field by assigning the `usageManager` instance, which implements the `UsageAggregator` interface
   - This resolves potential runtime nil pointer errors when the aggregator is accessed during service operation

2. **Extended UsageManager interface** (`core/usage.go`):
   - Added `GetAggregatedUsageByType(ctx context.Context, userID uint, usageType UsageType) (uint64, error)` method to support retrieving aggregated usage data filtered by specific usage type for a given user

3. **Updated mock implementation** (`core/mock_UsageManager.go`):
   - Added complete mock function implementation for `GetAggregatedUsageByType` including return value handling and type assertions
   - Added `MockUsageManager_GetAggregatedUsageByType_Call` struct with `Run`, `Return`, and `RunAndReturn` helper methods to support test expectations and argument matching
<!-- kody-pr-summary:end -->