### PR TITLE
fix(quota): prevent UpdateQuotaPlan from changing default plan

### DIFF
--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -401,6 +401,18 @@ func (s *QuotaServiceDefault) UpdateQuotaPlan(ctx context.Context, planID uint, 
 		return fmt.Errorf("database not initialized")
 	}
 
+	// Fetch the existing plan to check if IsDefault is being changed
+	var existing models.QuotaPlan
+	if err := s.DB().Where("id = ?", planID).First(&existing).Error; err != nil {
+		return fmt.Errorf("failed to fetch existing quota plan: %w", err)
+	}
+
+	// Block all attempts to change IsDefault through UpdateQuotaPlan
+	// Only SetDefaultQuotaPlan can change default status to prevent duplicate key violations
+	if existing.IsDefault != plan.IsDefault {
+		return fmt.Errorf("cannot change default quota plan status through update - use SetDefaultQuotaPlan to change the default plan")
+	}
+
 	err := core.MetricTrack(
 		nil,
 		policies.PlanOperationsErr.WithLabelValues(policies.LabelPlanOperationUpdate),
@@ -413,6 +425,7 @@ func (s *QuotaServiceDefault) UpdateQuotaPlan(ctx context.Context, planID uint, 
 				}
 
 				// Update the existing plan's fields with new values
+				// Note: IsDefault is not updated here unless handled by SetDefaultQuotaPlan
 				existing.Name = plan.Name
 				existing.Description = plan.Description
 				existing.StorageLimit = plan.StorageLimit
@@ -423,7 +436,7 @@ func (s *QuotaServiceDefault) UpdateQuotaPlan(ctx context.Context, planID uint, 
 				existing.StorageThreshold = plan.StorageThreshold
 				existing.UploadThreshold = plan.UploadThreshold
 				existing.DownloadThreshold = plan.DownloadThreshold
-				existing.IsDefault = plan.IsDefault
+				// existing.IsDefault intentionally not set here - must use SetDefaultQuotaPlan
 				existing.IsActive = plan.IsActive
 
 				// Save the existing record to trigger BeforeSave and BeforeUpdate hooks

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -978,6 +978,80 @@ func TestSetDefaultQuotaPlan_SwitchDefaultPlan(t *testing.T) {
 	}, testOptions())
 }
 
+// TestUpdateQuotaPlan_CannotChangeDefault tests that UpdateQuotaPlan rejects attempts
+// to change the IsDefault field. This is a regression test to ensure that only
+// SetDefaultQuotaPlan can change default plans, preventing duplicate key violations.
+func TestUpdateQuotaPlan_CannotChangeDefault(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a non-default plan
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan",
+			Description:        "Original plan",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(true),
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+		planID := plan.ID
+
+		// Act & Assert - Try to set IsDefault=true via UpdateQuotaPlan
+		updatePlan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan",
+			Description:        "Updated Plan",
+			StorageLimit:       5368709120,
+			UploadDailyLimit:   52428800,
+			DownloadDailyLimit: 262144000,
+			UploadTotalLimit:   5368709120,
+			DownloadTotalLimit: 2684354560,
+			IsDefault:          true, // Try to set to default
+			IsActive:           new(true),
+		}
+		err = quotaService.UpdateQuotaPlan(ctx, planID, updatePlan)
+		assert.Error(t, err, "UpdateQuotaPlan should return error when trying to change IsDefault to true")
+		assert.Contains(t, err.Error(), "cannot change default", "Error message should indicate the restriction")
+
+		// Verify plan was NOT updated
+		updatedPlan, err := quotaService.GetQuotaPlan(ctx, planID)
+		require.NoError(t, err)
+		assert.Equal(t, "Test Plan", updatedPlan.Name, "Plan name should remain unchanged")
+		assert.False(t, updatedPlan.IsDefault, "Plan should still not be default")
+
+		// Arrange - Set plan as default using proper method
+		err = quotaService.SetDefaultQuotaPlan(ctx, planID)
+		require.NoError(t, err)
+
+		// Act & Assert - Try to unset IsDefault via UpdateQuotaPlan
+		unsetPlan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan",
+			Description:        "Unset Default",
+			StorageLimit:       5368709120,
+			UploadDailyLimit:   52428800,
+			DownloadDailyLimit: 262144000,
+			UploadTotalLimit:   5368709120,
+			DownloadTotalLimit: 2684354560,
+			IsDefault:          false, // Try to unset default
+			IsActive:           new(true),
+		}
+		err = quotaService.UpdateQuotaPlan(ctx, planID, unsetPlan)
+		assert.Error(t, err, "UpdateQuotaPlan should return error when trying to unset IsDefault")
+		assert.Contains(t, err.Error(), "cannot change default", "Error message should indicate the restriction")
+
+		// Verify plan is still default
+		defaultPlan, err := quotaService.GetDefaultQuotaPlan(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, planID, defaultPlan.ID, "Plan should still be default")
+		assert.Equal(t, "Test Plan", defaultPlan.Name, "Plan name should remain unchanged")
+
+	}, testOptions())
+}
+
 // TestUpdateAllowanceGrant_PreservesUserID tests that updating an allowance grant
 // doesn't overwrite the UserID with zero when only some fields are specified.
 func TestUpdateAllowanceGrant_PreservesUserID(t *testing.T) {


### PR DESCRIPTION
Now UpdateQuotaPlan explicitly rejects any attempt to change the IsDefault field to prevent duplicate key constraint violations. The proper way to change the default plan is through the dedicated POST /plans/:planID/default endpoint, which calls SetDefaultQuotaPlan with the proper atomic switch logic.

This enforces the DRY principle: only SetDefaultQuotaPlan handles default plan changes. UpdateQuotaPlan is now limited to updating plan details like limits, name, and description.

Also added regression test TestUpdateQuotaPlan_CannotChangeDefault to verify that both setting and unsetting IsDefault through UpdateQuotaPlan are blocked and return an appropriate error message.

---

<!-- kody-pr-summary:start -->
 This PR fixes an issue where `UpdateQuotaPlan` could inadvertently change the default quota plan status, potentially causing duplicate key violations and data integrity issues.

**Changes:**
- Added validation in `UpdateQuotaPlan` to reject any attempts to modify the `IsDefault` field, returning a clear error message directing users to use `SetDefaultQuotaPlan` instead
- Removed the `IsDefault` field assignment from the update transaction to ensure it cannot be modified through general plan updates
- Added comprehensive test coverage verifying that attempts to set or unset the default status via `UpdateQuotaPlan` are properly rejected

**Impact:**
The default quota plan status can now only be changed through the dedicated `SetDefaultQuotaPlan` method, ensuring proper handling of default plan transitions and preventing scenarios where multiple plans could incorrectly be marked as default simultaneously.
<!-- kody-pr-summary:end -->