### PR TITLE
fix(quota): prevent CreateQuotaPlan from setting IsDefault=true

### DIFF
--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -359,6 +359,12 @@ func (s *QuotaServiceDefault) CreateQuotaPlan(ctx context.Context, plan *models.
 		return fmt.Errorf("database not initialized")
 	}
 
+	// Block creation with IsDefault=true to prevent duplicate key violations
+	// Use SetDefaultQuotaPlan to change which plan is default after creation
+	if plan.IsDefault {
+		return fmt.Errorf("cannot create plan with IsDefault=true - set an existing plan as default using SetDefaultQuotaPlan")
+	}
+
 	// Check if a plan with the same name already exists
 	// Note: We perform this pre-flight check as an optimization for early feedback,
 	// but we also handle UNIQUE constraint violations from the database during creation

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -1052,6 +1052,31 @@ func TestUpdateQuotaPlan_CannotChangeDefault(t *testing.T) {
 	}, testOptions())
 }
 
+// TestCreateQuotaPlan_CannotCreateAsDefault tests that CreateQuotaPlan rejects attempts
+// to create a plan with IsDefault=true. This prevents duplicate key violations
+// by ensuring default status must be set via SetDefaultQuotaPlan after creation.
+func TestCreateQuotaPlan_CannotCreateAsDefault(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Act & Assert - Try to create a plan with IsDefault=true
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Default Plan",
+			Description:        "Attempt to create as default",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          true, // This should be rejected
+			IsActive:           new(true),
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		assert.Error(t, err, "CreateQuotaPlan should return error when trying to create with IsDefault=true")
+		assert.Contains(t, err.Error(), "cannot create plan with IsDefault=true", "Error message should indicate the restriction")
+	}, testOptions())
+}
+
 // TestUpdateAllowanceGrant_PreservesUserID tests that updating an allowance grant
 // doesn't overwrite the UserID with zero when only some fields are specified.
 func TestUpdateAllowanceGrant_PreservesUserID(t *testing.T) {


### PR DESCRIPTION
Add validation to block creating plans with IsDefault=true, preventing duplicate key violations. Default status must be set via SetDefaultQuotaPlan after creation.

This fixes the third untested scenario where attempting to create a plan with IsDefault=true when another active default plan exists would trigger the 'uniq_default_active_one' constraint violation.

---

<!-- kody-pr-summary:start -->
 This pull request fixes an issue where creating a quota plan with `IsDefault=true` could cause duplicate key violations in the database. 

**Changes Made:**
- Modified `CreateQuotaPlan` to reject any attempt to create a plan with `IsDefault=true`, returning a clear error message directing users to use `SetDefaultQuotaPlan` instead
- Added test coverage to verify the restriction works correctly

**Functional Impact:**
Users can no longer designate a quota plan as default during creation. Instead, they must first create the plan with `IsDefault=false`, then use the separate `SetDefaultQuotaPlan` method to designate it as the default. This prevents database constraint violations that occur when multiple plans attempt to claim default status simultaneously during the creation process.
<!-- kody-pr-summary:end -->