### PR TITLE
fix(quota): handle soft-deleted plans when setting default quota plan

### DIFF
--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -553,11 +553,14 @@ func (s *QuotaServiceDefault) SetDefaultQuotaPlan(ctx context.Context, planID ui
 	// This ensures never more than one default, avoiding constraint violations
 	return db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 		// First, fetch and unset the current default plan (if any)
-		// Fetching the full model ensures validation hooks can run
+		// Use Unscoped() to include soft-deleted records, which prevents
+		// duplicate key violations when trying to set a new default plan
+		// after the old default has been soft-deleted
 		var currentDefault models.QuotaPlan
-		if tx.Where("is_default = ?", true).First(&currentDefault).Error == nil {
+		if tx.Unscoped().Where("is_default = ?", true).First(&currentDefault).Error == nil {
+			// Also use Unscoped() when saving to ensure we can update soft-deleted records
 			currentDefault.IsDefault = false
-			if result := tx.Save(&currentDefault); result.Error != nil {
+			if result := tx.Unscoped().Save(&currentDefault); result.Error != nil {
 				return result
 			}
 		}

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -1077,6 +1077,78 @@ func TestCreateQuotaPlan_CannotCreateAsDefault(t *testing.T) {
 	}, testOptions())
 }
 
+// TestSetDefaultQuotaPlan_AfterSoftDelete tests that setting a default plan still works
+// after the previous default plan has been soft-deleted. This edge case triggers
+// the 'uniq_default_active_one' constraint violation if soft-deleted records with
+// is_default=1 are not properly handled.
+func TestSetDefaultQuotaPlan_AfterSoftDelete(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create first plan and set as default
+		plan1 := &pluginModels.QuotaPlan{
+			Name:               "First Plan",
+			Description:        "First plan",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(true),
+		}
+		err := quotaService.CreateQuotaPlan(ctx, plan1)
+		require.NoError(t, err)
+		plan1ID := plan1.ID
+
+		err = quotaService.SetDefaultQuotaPlan(ctx, plan1ID)
+		require.NoError(t, err)
+
+		// Verify plan1 is default
+		defaultPlan, err := quotaService.GetDefaultQuotaPlan(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, plan1ID, defaultPlan.ID)
+
+		// Act - Soft-delete the default plan
+		// Simulates a scenario where a plan is marked as deleted but still exists in database
+		err = db.Model(&pluginModels.QuotaPlan{}).Where("id = ?", plan1ID).Delete(&pluginModels.QuotaPlan{}).Error
+		require.NoError(t, err, "Failed to soft-delete plan")
+
+		// Verify the plan is soft-deleted (exists in DB but has deleted_at set)
+		var count int64
+		err = db.Model(&pluginModels.QuotaPlan{}).Unscoped().Where("id = ?", plan1ID).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "Plan should still exist in database")
+
+		// Arrange - Create second plan and try to set as default
+		plan2 := &pluginModels.QuotaPlan{
+			Name:               "Second Plan",
+			Description:        "Second plan",
+			StorageLimit:       5368709120,
+			UploadDailyLimit:   52428800,
+			DownloadDailyLimit: 262144000,
+			UploadTotalLimit:   5368709120,
+			DownloadTotalLimit: 2684354560,
+			IsDefault:          false,
+			IsActive:           new(true),
+		}
+		err = quotaService.CreateQuotaPlan(ctx, plan2)
+		require.NoError(t, err)
+		plan2ID := plan2.ID
+
+		// Act - This should NOT fail with duplicate entry error
+		err = quotaService.SetDefaultQuotaPlan(ctx, plan2ID)
+		assert.NoError(t, err, "Setting new default after soft-delete should succeed")
+
+		// Verify plan2 is now default
+		newDefaultPlan, err := quotaService.GetDefaultQuotaPlan(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, plan2ID, newDefaultPlan.ID, "Second plan should now be default")
+		assert.True(t, newDefaultPlan.IsDefault, "New plan should be marked as default")
+	}, testOptions())
+}
+
 // TestUpdateAllowanceGrant_PreservesUserID tests that updating an allowance grant
 // doesn't overwrite the UserID with zero when only some fields are specified.
 func TestUpdateAllowanceGrant_PreservesUserID(t *testing.T) {


### PR DESCRIPTION
Use Unscoped() in SetDefaultQuotaPlan to find and update soft-deleted records with is_default=true before setting a new default. This prevents the 'uniq_default_active_one' constraint violation when:

1. A plan is set as default (is_default=true, is_active=true)
2. The plan is soft-deleted (deleted_at is set, but is_default=true remains)
3. A new default plan is set (fails because the soft-deleted plan still has is_default=true, violating the unique constraint)

This fixes the fourth edge case where soft-deleted records still count against the unique constraint.

---

<!-- kody-pr-summary:start -->
 Fixes a bug where setting a new default quota plan fails with a duplicate entry error when the previous default plan has been soft-deleted. 

The issue occurred because soft-deleted records retaining `is_default=true` were not being found when attempting to unset the current default, causing unique constraint violations. The fix uses GORM's `Unscoped()` method to include soft-deleted records when querying and updating the current default plan, ensuring the `is_default` flag is properly cleared on soft-deleted records before assigning a new default.

Includes a new test case verifying that setting a default plan succeeds after the previous default has been soft-deleted.
<!-- kody-pr-summary:end -->