### PR TITLE
fix(api): correct swagger response field mappings for list endpoints

### DIFF
--- a/internal/api/dto/admin_quota.go
+++ b/internal/api/dto/admin_quota.go
@@ -105,11 +105,11 @@ func (r *QuotaPlanResponse) FromModel(model *models.QuotaPlan) error {
 //
 // This struct exists due to a swagger documentation generation bug where queryutil.Response generics
 // are not getting detected properly as an array type. By providing a concrete struct, we ensure the
-// swagger docs correctly show the plans field as an array of QuotaPlanResponse items.
+// swagger docs correctly show the Plans field (mapped to "data" in JSON) as an array of QuotaPlanResponse items.
 //
 // Note: This struct is only used for swagger documentation, not for actual encoding.
 type PlanListResponse struct {
-	Plans []QuotaPlanResponse `json:"plans"`
+	Plans []QuotaPlanResponse `json:"data"`
 	Total int                 `json:"total"`
 }
 
@@ -208,11 +208,11 @@ func (r *AllowanceGrantResponse) FromModel(model *models.AllowanceGrant) error {
 //
 // This struct exists due to a swagger documentation generation bug where queryutil.Response generics
 // are not getting detected properly as an array type. By providing a concrete struct, we ensure the
-// swagger docs correctly show the grants field as an array of AllowanceGrantResponse items.
+// swagger docs correctly show the Grants field (mapped to "data" in JSON) as an array of AllowanceGrantResponse items.
 //
 // Note: This struct is only used for swagger documentation, not for actual encoding.
 type AllowanceListResponse struct {
-	Grants []AllowanceGrantResponse `json:"grants"`
+	Grants []AllowanceGrantResponse `json:"data"`
 	Total  int                      `json:"total"`
 }
 


### PR DESCRIPTION
Fix swagger documentation for PlanListResponse and AllowanceListResponse to match the actual API response format. The field names were mapped to 'plans' and 'grants' respectively, but the actual API returns data in a 'data' field as defined by queryutil.Response generics.

This aligns the swagger documentation with the runtime API behavior, preventing client SDKs from looking in the wrong field location.

---

<!-- kody-pr-summary:start -->
 This pull request fixes the Swagger/OpenAPI documentation for list endpoints to accurately reflect the actual API response structure. 

The changes correct the JSON field mapping in the response documentation structs for quota plans and allowance grants. Previously, the documentation indicated these list responses used field names "plans" and "grants" respectively, but the actual API returns these arrays under the "data" field. This update aligns the Swagger documentation with the real API behavior, ensuring that generated API documentation and client SDKs correctly represent the response payload structure for the quota plan listing and allowance grant listing endpoints.
<!-- kody-pr-summary:end -->