### PR TITLE
fix(quota): handle all enforcement policies in quota status API

### DIFF
--- a/internal/api/dto/quota.go
+++ b/internal/api/dto/quota.go
@@ -2,9 +2,9 @@ package dto
 
 // QuotaStatusResponse represents current quota status for progress bars
 type QuotaStatusResponse struct {
-	Upload    QuotaTypeStatus `json:"upload"`
-	Download  QuotaTypeStatus `json:"download"`
-	Bandwidth QuotaTypeStatus `json:"bandwidth,omitempty"`
+	Upload   QuotaTypeStatus `json:"upload"`
+	Download QuotaTypeStatus `json:"download"`
+	Storage  QuotaTypeStatus `json:"storage"`
 }
 
 // FromModel implements DTOResponse interface
@@ -18,6 +18,7 @@ type QuotaTypeStatus struct {
 	Limit      *uint64 `json:"limit,omitempty"`
 	Remaining  *uint64 `json:"remaining,omitempty"`
 	Percentage *int    `json:"percentage"`
+	Threshold  *uint64 `json:"threshold,omitempty"`
 }
 
 // QuotaHistoryRequest parameters for historical data query

--- a/internal/api/quota_extension.go
+++ b/internal/api/quota_extension.go
@@ -105,11 +105,9 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 	}
 
 	// Get user's quota config to determine policy
-	config, err := e.quotaService.GetConfigManager().GetUserQuotaConfig(e.Context(), userID)
+	config, err := e.quotaService.GetConfigManager().GetUserQuotaConfig(ctx.Request().Context(), userID)
 	if err != nil {
-		e.Logger().Error("failed to get user quota config", zap.Error(err))
-		apiErr := NewError(ErrKeyQuotaFetchFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+		return e.handleQuotaError(ctx, "failed to get user quota config", err)
 	}
 
 	var response dto.QuotaStatusResponse
@@ -118,51 +116,46 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 	switch config.EnforcementPolicy {
 	case models.EnforcementPolicyAllowance:
 		// ALLOWANCE: Use ad-hoc grants (PAYG style)
-		balance, err := e.quotaService.GetAllowanceBalance(e.Context(), userID)
+		balance, err := e.quotaService.GetAllowanceBalance(ctx.Request().Context(), userID)
 		if err != nil {
-			e.Logger().Error("failed to get allowance balance", zap.Error(err))
-			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
+			return e.handleQuotaError(ctx, "failed to get allowance balance", err)
 		}
 
 		response = dto.QuotaStatusResponse{
 			Upload:   e.buildQuotaTypeStatus(balance.UploadUsed, balance.UploadAllowance, balance.UploadRemaining),
 			Download: e.buildQuotaTypeStatus(balance.DownloadUsed, balance.DownloadAllowance, balance.DownloadRemaining),
+			Storage:  e.buildQuotaTypeStatus(balance.StorageUsed, balance.StorageAllowance, balance.StorageRemaining),
 		}
 
 	case models.EnforcementPolicyUnlimited:
 		// UNLIMITED: Show usage without limits
-		usage, err := e.quotaService.GetUsageManager().GetCurrentUsage(e.Context(), userID)
+		usage, err := e.quotaService.GetUsageManager().GetCurrentUsage(ctx.Request().Context(), userID)
 		if err != nil {
-			e.Logger().Error("failed to get current usage", zap.Error(err))
-			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
+			return e.handleQuotaError(ctx, "failed to get current usage", err)
 		}
 
 		response = dto.QuotaStatusResponse{
 			Upload:   e.buildUnlimitedStatus(usage.BytesUploaded),
 			Download: e.buildUnlimitedStatus(usage.BytesDownloaded),
+			Storage:  e.buildUnlimitedStatus(usage.BytesStored),
 		}
 
 	case models.EnforcementPolicyHardLimits, models.EnforcementPolicyThreshold:
 		// HARD_LIMITS and THRESHOLD: Show effective limits and current usage
-		usage, err := e.quotaService.GetUsageManager().GetCurrentUsage(e.Context(), userID)
+		usage, err := e.quotaService.GetUsageManager().GetCurrentUsage(ctx.Request().Context(), userID)
 		if err != nil {
-			e.Logger().Error("failed to get current usage", zap.Error(err))
-			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
+			return e.handleQuotaError(ctx, "failed to get current usage", err)
 		}
 
-		limits, err := e.quotaService.GetConfigManager().ResolveEffectiveLimits(e.Context(), userID)
+		limits, err := e.quotaService.GetConfigManager().ResolveEffectiveLimits(ctx.Request().Context(), userID)
 		if err != nil {
-			e.Logger().Error("failed to resolve effective limits", zap.Error(err))
-			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
+			return e.handleQuotaError(ctx, "failed to resolve effective limits", err)
 		}
 
 		response = dto.QuotaStatusResponse{
 			Upload:   e.buildLimitedStatus(usage.BytesUploaded, limits.UploadDailyLimit, limits.UploadThreshold),
 			Download: e.buildLimitedStatus(usage.BytesDownloaded, limits.DownloadDailyLimit, limits.DownloadThreshold),
+			Storage:  e.buildLimitedStatus(usage.BytesStored, limits.StorageLimit, nil),
 		}
 
 	default:
@@ -272,6 +265,13 @@ func (e *QuotaExtension) getUser(ctx httputil.RequestContext) (uint, bool) {
 	return user, true
 }
 
+// handleQuotaError handles quota-related errors with consistent logging and response formatting
+func (e *QuotaExtension) handleQuotaError(ctx httputil.RequestContext, msg string, err error) error {
+	e.Logger().Error(msg, zap.Error(err))
+	apiErr := NewError(ErrKeyQuotaFetchFailed, err)
+	return ctx.Error(apiErr, apiErr.HttpStatus())
+}
+
 // buildUnlimitedStatus builds a quota type status for unlimited usage
 func (e *QuotaExtension) buildUnlimitedStatus(used uint64) dto.QuotaTypeStatus {
 	return dto.QuotaTypeStatus{
@@ -307,5 +307,6 @@ func (e *QuotaExtension) buildLimitedStatus(used uint64, limit, threshold *uint6
 		Limit:      limit,
 		Remaining:  remaining,
 		Percentage: percentage,
+		Threshold:  threshold,
 	}
 }

--- a/internal/api/quota_extension.go
+++ b/internal/api/quota_extension.go
@@ -15,6 +15,7 @@ import (
 	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal-plugin-quota/internal/api/dto"
+	models "go.lumeweb.com/portal-plugin-quota/internal/db/models"
 	"go.lumeweb.com/portal-plugin-quota/internal"
 	"go.uber.org/zap"
 )
@@ -103,16 +104,71 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	balance, err := e.quotaService.GetAllowanceBalance(e.Context(), userID)
+	// Get user's quota config to determine policy
+	config, err := e.quotaService.GetConfigManager().GetUserQuotaConfig(e.Context(), userID)
 	if err != nil {
-		e.Logger().Error("failed to get allowance balance", zap.Error(err))
+		e.Logger().Error("failed to get user quota config", zap.Error(err))
 		apiErr := NewError(ErrKeyQuotaFetchFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	response := dto.QuotaStatusResponse{
-		Upload:   e.buildQuotaTypeStatus(balance.UploadUsed, balance.UploadAllowance, balance.UploadRemaining),
-		Download: e.buildQuotaTypeStatus(balance.DownloadUsed, balance.DownloadAllowance, balance.DownloadRemaining),
+	var response dto.QuotaStatusResponse
+
+	// Handle based on enforcement policy
+	switch config.EnforcementPolicy {
+	case models.EnforcementPolicyAllowance:
+		// ALLOWANCE: Use ad-hoc grants (PAYG style)
+		balance, err := e.quotaService.GetAllowanceBalance(e.Context(), userID)
+		if err != nil {
+			e.Logger().Error("failed to get allowance balance", zap.Error(err))
+			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+
+		response = dto.QuotaStatusResponse{
+			Upload:   e.buildQuotaTypeStatus(balance.UploadUsed, balance.UploadAllowance, balance.UploadRemaining),
+			Download: e.buildQuotaTypeStatus(balance.DownloadUsed, balance.DownloadAllowance, balance.DownloadRemaining),
+		}
+
+	case models.EnforcementPolicyUnlimited:
+		// UNLIMITED: Show usage without limits
+		usage, err := e.quotaService.GetUsageManager().GetCurrentUsage(e.Context(), userID)
+		if err != nil {
+			e.Logger().Error("failed to get current usage", zap.Error(err))
+			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+
+		response = dto.QuotaStatusResponse{
+			Upload:   e.buildUnlimitedStatus(usage.BytesUploaded),
+			Download: e.buildUnlimitedStatus(usage.BytesDownloaded),
+		}
+
+	case models.EnforcementPolicyHardLimits, models.EnforcementPolicyThreshold:
+		// HARD_LIMITS and THRESHOLD: Show effective limits and current usage
+		usage, err := e.quotaService.GetUsageManager().GetCurrentUsage(e.Context(), userID)
+		if err != nil {
+			e.Logger().Error("failed to get current usage", zap.Error(err))
+			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+
+		limits, err := e.quotaService.GetConfigManager().ResolveEffectiveLimits(e.Context(), userID)
+		if err != nil {
+			e.Logger().Error("failed to resolve effective limits", zap.Error(err))
+			apiErr := NewError(ErrKeyQuotaFetchFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+
+		response = dto.QuotaStatusResponse{
+			Upload:   e.buildLimitedStatus(usage.BytesUploaded, limits.UploadDailyLimit, limits.UploadThreshold),
+			Download: e.buildLimitedStatus(usage.BytesDownloaded, limits.DownloadDailyLimit, limits.DownloadThreshold),
+		}
+
+	default:
+		e.Logger().Warn("unknown enforcement policy", zap.String("policy", string(config.EnforcementPolicy)))
+		apiErr := NewError(ErrKeyQuotaFetchFailed, fmt.Errorf("unknown enforcement policy: %s", config.EnforcementPolicy))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	return httputil.EncodeResponse(ctx, response, response)
@@ -216,4 +272,40 @@ func (e *QuotaExtension) getUser(ctx httputil.RequestContext) (uint, bool) {
 	return user, true
 }
 
+// buildUnlimitedStatus builds a quota type status for unlimited usage
+func (e *QuotaExtension) buildUnlimitedStatus(used uint64) dto.QuotaTypeStatus {
+	return dto.QuotaTypeStatus{
+		Used:       used,
+		Limit:      nil, // nil indicates unlimited
+		Remaining:  nil,
+		Percentage: nil,
+	}
+}
 
+// buildLimitedStatus builds a quota type status for limits and thresholds
+func (e *QuotaExtension) buildLimitedStatus(used uint64, limit, threshold *uint64) dto.QuotaTypeStatus {
+	var remaining *uint64
+	var percentage *int
+
+	// Calculate remaining if limit is set
+	if limit != nil {
+		if used < *limit {
+			r := *limit - used
+			remaining = &r
+		} else {
+			zero := uint64(0)
+			remaining = &zero
+		}
+
+		// Calculate percentage
+		p := e.calculateProgress(used, *limit)
+		percentage = &p
+	}
+
+	return dto.QuotaTypeStatus{
+		Used:       used,
+		Limit:      limit,
+		Remaining:  remaining,
+		Percentage: percentage,
+	}
+}

--- a/internal/api/quota_extension_test.go
+++ b/internal/api/quota_extension_test.go
@@ -15,24 +15,34 @@ import (
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal-plugin-quota/internal/api/dto"
+	"go.lumeweb.com/portal-plugin-quota/internal/db/models"
+	"github.com/docker/go-units"
 )
 
 func TestHandleQuotaStatus_Success(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		helper := NewQuotaTestHelper(t, ctx)
 		quotaSvc := helper.GetQuotaService()
-		
+
 		// Setup authentication with a default user
 		helper.SetupAuth()
-		
+
+		// Mock config manager to support ALLOWANCE policy (default behavior)
+		mockConfigManager := quotaCore.NewMockConfigManager(t)
+		quotaSvc.EXPECT().GetConfigManager().Return(mockConfigManager)
+		mockConfigManager.EXPECT().GetUserQuotaConfig(mock.Anything, uint(1)).
+			Return(&quotaCore.UserQuotaConfig{
+				EnforcementPolicy: models.EnforcementPolicyAllowance,
+			}, nil).Once()
+
 		quotaSvc.EXPECT().GetAllowanceBalance(mock.Anything, uint(1)).
 			Return(&quotaCore.AllowanceBalance{
-				UploadUsed:       1000,
-				UploadAllowance:   10000,
-				UploadRemaining:   9000,
-				DownloadUsed:      2000,
-				DownloadAllowance: 20000,
-				DownloadRemaining: 18000,
+				UploadUsed:       uint64(units.GiB),
+				UploadAllowance:   uint64(units.GiB * 10),
+				UploadRemaining:   uint64(units.GiB * 9),
+				DownloadUsed:      uint64(units.GiB * 2),
+				DownloadAllowance: uint64(units.GiB * 20),
+				DownloadRemaining: uint64(units.GiB * 18),
 			}, nil).Once()
 
 		// Execute request using helper which properly handles auth
@@ -48,14 +58,14 @@ func TestHandleQuotaStatus_Success(t *testing.T) {
 		require.NotNil(t, response.Upload, "Upload section should not be nil")
 		require.NotNil(t, response.Upload.Limit, "Upload.Limit should not be nil")
 
-		assert.Equal(t, uint64(1000), response.Upload.Used)
-		assert.Equal(t, uint64(10000), *response.Upload.Limit)
-		assert.Equal(t, uint64(9000), *response.Upload.Remaining)
+		assert.Equal(t, uint64(units.GiB), response.Upload.Used)
+		assert.Equal(t, uint64(units.GiB*10), *response.Upload.Limit)
+		assert.Equal(t, uint64(units.GiB*9), *response.Upload.Remaining)
 		assert.Equal(t, 10, *response.Upload.Percentage)
 
-		assert.Equal(t, uint64(2000), response.Download.Used)
-		assert.Equal(t, uint64(20000), *response.Download.Limit)
-		assert.Equal(t, uint64(18000), *response.Download.Remaining)
+		assert.Equal(t, uint64(units.GiB*2), response.Download.Used)
+		assert.Equal(t, uint64(units.GiB*20), *response.Download.Limit)
+		assert.Equal(t, uint64(units.GiB*18), *response.Download.Remaining)
 		assert.Equal(t, 10, *response.Download.Percentage)
 	}, QuotaTestOptions)
 }
@@ -92,11 +102,11 @@ func TestHandleQuotaHistory_Success(t *testing.T) {
 			Return([]*quotaCore.UsagePoint{
 				{
 					Date:  parseTime(t, "2024-01-15T12:00:00Z"),
-					Bytes: 5000,
+					Bytes: uint64(units.MiB * 100),
 				},
 				{
 					Date:  parseTime(t, "2024-01-16T12:00:00Z"),
-					Bytes: 7500,
+					Bytes: uint64(units.MiB * 150),
 				},
 			}, nil).Once()
 
@@ -113,9 +123,9 @@ func TestHandleQuotaHistory_Success(t *testing.T) {
 		assert.Equal(t, uint(1), response.UserID)
 		assert.Equal(t, 2, len(response.Points))
 		assert.Equal(t, "2024-01-15T12:00:00Z", response.Points[0].Date)
-		assert.Equal(t, uint64(5000), response.Points[0].Bytes)
+		assert.Equal(t, uint64(units.MiB*100), response.Points[0].Bytes)
 		assert.Equal(t, "2024-01-16T12:00:00Z", response.Points[1].Date)
-		assert.Equal(t, uint64(7500), response.Points[1].Bytes)
+		assert.Equal(t, uint64(units.MiB*150), response.Points[1].Bytes)
 	}, QuotaTestOptions)
 }
 
@@ -144,6 +154,190 @@ func TestHandleQuotaHistory_InvalidDateFormat(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
 	}, QuotaTestOptions)
 }
+
+// TestHandleQuotaStatus_UnlimitedPolicy tests the UNLIMITED enforcement policy
+func TestHandleQuotaStatus_UnlimitedPolicy(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := NewQuotaTestHelper(t, ctx)
+		quotaSvc := helper.GetQuotaService()
+
+		helper.SetupAuth()
+
+		mockConfigManager := quotaCore.NewMockConfigManager(t)
+		quotaSvc.EXPECT().GetConfigManager().Return(mockConfigManager)
+		mockConfigManager.EXPECT().GetUserQuotaConfig(mock.Anything, uint(1)).
+			Return(&quotaCore.UserQuotaConfig{
+				EnforcementPolicy: models.EnforcementPolicyUnlimited,
+			}, nil).Once()
+
+		mockUsageManager := quotaCore.NewMockUsageManager(t)
+		quotaSvc.EXPECT().GetUsageManager().Return(mockUsageManager)
+		mockUsageManager.EXPECT().GetCurrentUsage(mock.Anything, uint(1)).
+			Return(&quotaCore.Usage{
+				BytesUploaded:   uint64(units.GiB * 5),
+				BytesDownloaded: uint64(units.GiB * 10),
+			}, nil).Once()
+
+		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response dto.QuotaStatusResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(units.GiB*5), response.Upload.Used)
+		assert.Equal(t, uint64(units.GiB*10), response.Download.Used)
+		assert.Nil(t, response.Upload.Limit)
+		assert.Nil(t, response.Download.Limit)
+		assert.Nil(t, response.Upload.Remaining)
+		assert.Nil(t, response.Download.Remaining)
+	}, QuotaTestOptions)
+}
+
+// TestHandleQuotaStatus_HardLimitsPolicy tests the HARD_LIMITS enforcement policy
+func TestHandleQuotaStatus_HardLimitsPolicy(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := NewQuotaTestHelper(t, ctx)
+		quotaSvc := helper.GetQuotaService()
+
+		helper.SetupAuth()
+
+		mockConfigManager := quotaCore.NewMockConfigManager(t)
+		quotaSvc.EXPECT().GetConfigManager().Return(mockConfigManager)
+		mockConfigManager.EXPECT().GetUserQuotaConfig(mock.Anything, uint(1)).
+			Return(&quotaCore.UserQuotaConfig{
+				EnforcementPolicy: models.EnforcementPolicyHardLimits,
+			}, nil).Once()
+
+		uploadLimit := uint64(units.MiB * 100)
+		downloadLimit := uint64(units.MiB * 500)
+		mockConfigManager.EXPECT().ResolveEffectiveLimits(mock.Anything, uint(1)).
+			Return(&quotaCore.EffectiveLimits{
+				UploadDailyLimit:   &uploadLimit,
+				DownloadDailyLimit: &downloadLimit,
+				HasUploadDailyLimitConfig:   true,
+				HasDownloadDailyLimitConfig: true,
+			}, nil).Once()
+
+		mockUsageManager := quotaCore.NewMockUsageManager(t)
+		quotaSvc.EXPECT().GetUsageManager().Return(mockUsageManager)
+		mockUsageManager.EXPECT().GetCurrentUsage(mock.Anything, uint(1)).
+			Return(&quotaCore.Usage{
+				BytesUploaded:   uint64(units.MiB * 30),
+				BytesDownloaded: uint64(units.MiB * 150),
+			}, nil).Once()
+
+		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response dto.QuotaStatusResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(units.MiB*30), response.Upload.Used)
+		assert.Equal(t, uint64(units.MiB*100), *response.Upload.Limit)
+		assert.Equal(t, uint64(units.MiB*70), *response.Upload.Remaining)
+		assert.Equal(t, 30, *response.Upload.Percentage)
+	}, QuotaTestOptions)
+}
+
+// TestHandleQuotaStatus_ThresholdPolicy tests the THRESHOLD enforcement policy
+func TestHandleQuotaStatus_ThresholdPolicy(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := NewQuotaTestHelper(t, ctx)
+		quotaSvc := helper.GetQuotaService()
+
+		helper.SetupAuth()
+
+		mockConfigManager := quotaCore.NewMockConfigManager(t)
+		quotaSvc.EXPECT().GetConfigManager().Return(mockConfigManager)
+		mockConfigManager.EXPECT().GetUserQuotaConfig(mock.Anything, uint(1)).
+			Return(&quotaCore.UserQuotaConfig{
+				EnforcementPolicy: models.EnforcementPolicyThreshold,
+			}, nil).Once()
+
+		uploadLimit := uint64(units.MiB * 100)
+		downloadLimit := uint64(units.MiB * 500)
+		uploadThreshold := uint64(80)
+		downloadThreshold := uint64(90)
+		mockConfigManager.EXPECT().ResolveEffectiveLimits(mock.Anything, uint(1)).
+			Return(&quotaCore.EffectiveLimits{
+				UploadDailyLimit:   &uploadLimit,
+				DownloadDailyLimit: &downloadLimit,
+				UploadThreshold:    &uploadThreshold,
+				DownloadThreshold:  &downloadThreshold,
+				HasUploadDailyLimitConfig:        true,
+				HasDownloadDailyLimitConfig:      true,
+				HasUploadThresholdConfig:         true,
+				HasDownloadThresholdConfig:       true,
+			}, nil).Once()
+
+		mockUsageManager := quotaCore.NewMockUsageManager(t)
+		quotaSvc.EXPECT().GetUsageManager().Return(mockUsageManager)
+		mockUsageManager.EXPECT().GetCurrentUsage(mock.Anything, uint(1)).
+			Return(&quotaCore.Usage{
+				BytesUploaded:   uint64(units.MiB * 80),
+				BytesDownloaded: uint64(units.MiB * 450),
+			}, nil).Once()
+
+		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response dto.QuotaStatusResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(units.MiB*80), response.Upload.Used)
+		assert.Equal(t, uint64(units.MiB*100), *response.Upload.Limit)
+		assert.Equal(t, uint64(units.MiB*20), *response.Upload.Remaining)
+		assert.Equal(t, 80, *response.Upload.Percentage)
+	}, QuotaTestOptions)
+}
+
+// TestHandleQuotaStatus_AllowancePolicy tests the ALLOWANCE enforcement policy
+func TestHandleQuotaStatus_AllowancePolicy(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := NewQuotaTestHelper(t, ctx)
+		quotaSvc := helper.GetQuotaService()
+
+		helper.SetupAuth()
+
+		mockConfigManager := quotaCore.NewMockConfigManager(t)
+		quotaSvc.EXPECT().GetConfigManager().Return(mockConfigManager)
+		mockConfigManager.EXPECT().GetUserQuotaConfig(mock.Anything, uint(1)).
+			Return(&quotaCore.UserQuotaConfig{
+				EnforcementPolicy: models.EnforcementPolicyAllowance,
+			}, nil).Once()
+
+		quotaSvc.EXPECT().GetAllowanceBalance(mock.Anything, uint(1)).
+			Return(&quotaCore.AllowanceBalance{
+				UploadUsed:        uint64(units.GiB * 5),
+				UploadAllowance:   uint64(units.GiB * 10),
+				UploadRemaining:    uint64(units.GiB * 5),
+				DownloadUsed:      uint64(units.GiB * 12),
+				DownloadAllowance: uint64(units.GiB * 20),
+				DownloadRemaining:  uint64(units.GiB * 8),
+			}, nil).Once()
+
+		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response dto.QuotaStatusResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(units.GiB*5), response.Upload.Used)
+		assert.Equal(t, uint64(units.GiB*10), *response.Upload.Limit)
+		assert.Equal(t, uint64(units.GiB*5), *response.Upload.Remaining)
+		assert.Equal(t, 50, *response.Upload.Percentage)
+	}, QuotaTestOptions)
+}
+
+// test helpers
 
 // parseTime is a helper to parse RFC3339 timestamps in tests
 func parseTime(t *testing.T, timestamp string) time.Time {


### PR DESCRIPTION
- Fix /api/account/quota endpoint to properly respect all four enforcement policies
- Add comprehensive unit tests for ALLOWANCE, UNLIMITED, HARD_LIMITS, and THRESHOLD policies
- Update test data to use docker/go-units (GiB, MiB) for readability
- Use EnforcementPolicy* constants instead of string literals
- Ensure users with plan-based quotas see correct limits and actual usage

---

<!-- kody-pr-summary:start -->
 This pull request fixes the quota status API endpoint to properly support all enforcement policies, not just the Allowance policy.

**Changes Made:**

- **Extended Policy Support**: Modified the quota status handler to detect the user's configured enforcement policy (Allowance, Unlimited, Hard Limits, or Threshold) and return appropriate quota data for each policy type:
  - **Allowance**: Returns ad-hoc grant balances (used/remaining from PAYG-style credits)
  - **Unlimited**: Returns usage statistics without limits (null limits indicate unlimited)
  - **Hard Limits/Threshold**: Returns current usage against effective daily limits with threshold warnings

- **Dynamic Response Construction**: Added logic to calculate remaining quotas and usage percentages based on the specific policy type, ensuring the API returns meaningful data regardless of how quota enforcement is configured.

- **Comprehensive Test Coverage**: Added test cases for all four enforcement policies (Unlimited, Hard Limits, Threshold, and Allowance) to verify correct behavior across different quota configurations, along with updating existing tests to use standardized units (GiB/MiB).

**Impact:**
The quota status API now correctly displays quota information for users regardless of whether they are on unlimited plans, hard limit plans, threshold-based plans, or allowance-based (PAYG) plans. Previously, the API only worked correctly for allowance-based quotas and would have returned incorrect or incomplete data for other policy types.
<!-- kody-pr-summary:end -->