### PR TITLE
feat(quota): add admin APIs for user quota config management

### DIFF
--- a/core/mock_QuotaService.go
+++ b/core/mock_QuotaService.go
@@ -2353,6 +2353,92 @@ func (_c *MockQuotaService_ListQuotaPlans_Call) RunAndReturn(run func(ctx contex
 	return _c
 }
 
+// ListUserQuotaConfigs provides a mock function for the type MockQuotaService
+func (_mock *MockQuotaService) ListUserQuotaConfigs(ctx context.Context, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*UserQuotaConfig, int64, error) {
+	ret := _mock.Called(ctx, filters, sorts, pagination)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListUserQuotaConfigs")
+	}
+
+	var r0 []*UserQuotaConfig
+	var r1 int64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) ([]*UserQuotaConfig, int64, error)); ok {
+		return returnFunc(ctx, filters, sorts, pagination)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) []*UserQuotaConfig); ok {
+		r0 = returnFunc(ctx, filters, sorts, pagination)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*UserQuotaConfig)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) int64); ok {
+		r1 = returnFunc(ctx, filters, sorts, pagination)
+	} else {
+		r1 = ret.Get(1).(int64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) error); ok {
+		r2 = returnFunc(ctx, filters, sorts, pagination)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockQuotaService_ListUserQuotaConfigs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListUserQuotaConfigs'
+type MockQuotaService_ListUserQuotaConfigs_Call struct {
+	*mock.Call
+}
+
+// ListUserQuotaConfigs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - filters []queryutil.CrudFilter
+//   - sorts []queryutil.Sort
+//   - pagination queryutil.Pagination
+func (_e *MockQuotaService_Expecter) ListUserQuotaConfigs(ctx interface{}, filters interface{}, sorts interface{}, pagination interface{}) *MockQuotaService_ListUserQuotaConfigs_Call {
+	return &MockQuotaService_ListUserQuotaConfigs_Call{Call: _e.mock.On("ListUserQuotaConfigs", ctx, filters, sorts, pagination)}
+}
+
+func (_c *MockQuotaService_ListUserQuotaConfigs_Call) Run(run func(ctx context.Context, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination)) *MockQuotaService_ListUserQuotaConfigs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []queryutil.CrudFilter
+		if args[1] != nil {
+			arg1 = args[1].([]queryutil.CrudFilter)
+		}
+		var arg2 []queryutil.Sort
+		if args[2] != nil {
+			arg2 = args[2].([]queryutil.Sort)
+		}
+		var arg3 queryutil.Pagination
+		if args[3] != nil {
+			arg3 = args[3].(queryutil.Pagination)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuotaService_ListUserQuotaConfigs_Call) Return(vs []*UserQuotaConfig, n int64, err error) *MockQuotaService_ListUserQuotaConfigs_Call {
+	_c.Call.Return(vs, n, err)
+	return _c
+}
+
+func (_c *MockQuotaService_ListUserQuotaConfigs_Call) RunAndReturn(run func(ctx context.Context, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*UserQuotaConfig, int64, error)) *MockQuotaService_ListUserQuotaConfigs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Logger provides a mock function for the type MockQuotaService
 func (_mock *MockQuotaService) Logger() *core.Logger {
 	ret := _mock.Called()
@@ -2785,6 +2871,63 @@ func (_c *MockQuotaService_ResetAllowance_Call) Return(err error) *MockQuotaServ
 }
 
 func (_c *MockQuotaService_ResetAllowance_Call) RunAndReturn(run func(ctx context.Context, userID uint) error) *MockQuotaService_ResetAllowance_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResetUserQuotaPlan provides a mock function for the type MockQuotaService
+func (_mock *MockQuotaService) ResetUserQuotaPlan(ctx context.Context, userID uint) error {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResetUserQuotaPlan")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockQuotaService_ResetUserQuotaPlan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetUserQuotaPlan'
+type MockQuotaService_ResetUserQuotaPlan_Call struct {
+	*mock.Call
+}
+
+// ResetUserQuotaPlan is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+func (_e *MockQuotaService_Expecter) ResetUserQuotaPlan(ctx interface{}, userID interface{}) *MockQuotaService_ResetUserQuotaPlan_Call {
+	return &MockQuotaService_ResetUserQuotaPlan_Call{Call: _e.mock.On("ResetUserQuotaPlan", ctx, userID)}
+}
+
+func (_c *MockQuotaService_ResetUserQuotaPlan_Call) Run(run func(ctx context.Context, userID uint)) *MockQuotaService_ResetUserQuotaPlan_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuotaService_ResetUserQuotaPlan_Call) Return(err error) *MockQuotaService_ResetUserQuotaPlan_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockQuotaService_ResetUserQuotaPlan_Call) RunAndReturn(run func(ctx context.Context, userID uint) error) *MockQuotaService_ResetUserQuotaPlan_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3242,6 +3385,69 @@ func (_c *MockQuotaService_UpdateQuotaPlan_Call) Return(err error) *MockQuotaSer
 }
 
 func (_c *MockQuotaService_UpdateQuotaPlan_Call) RunAndReturn(run func(ctx context.Context, planID uint, plan *models.QuotaPlan) error) *MockQuotaService_UpdateQuotaPlan_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateUserQuotaConfig provides a mock function for the type MockQuotaService
+func (_mock *MockQuotaService) UpdateUserQuotaConfig(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) error {
+	ret := _mock.Called(ctx, userID, update)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUserQuotaConfig")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, *UserQuotaConfigUpdate) error); ok {
+		r0 = returnFunc(ctx, userID, update)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockQuotaService_UpdateUserQuotaConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserQuotaConfig'
+type MockQuotaService_UpdateUserQuotaConfig_Call struct {
+	*mock.Call
+}
+
+// UpdateUserQuotaConfig is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+//   - update *UserQuotaConfigUpdate
+func (_e *MockQuotaService_Expecter) UpdateUserQuotaConfig(ctx interface{}, userID interface{}, update interface{}) *MockQuotaService_UpdateUserQuotaConfig_Call {
+	return &MockQuotaService_UpdateUserQuotaConfig_Call{Call: _e.mock.On("UpdateUserQuotaConfig", ctx, userID, update)}
+}
+
+func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) Run(run func(ctx context.Context, userID uint, update *UserQuotaConfigUpdate)) *MockQuotaService_UpdateUserQuotaConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 *UserQuotaConfigUpdate
+		if args[2] != nil {
+			arg2 = args[2].(*UserQuotaConfigUpdate)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) Return(err error) *MockQuotaService_UpdateUserQuotaConfig_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) RunAndReturn(run func(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) error) *MockQuotaService_UpdateUserQuotaConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/mock_QuotaService.go
+++ b/core/mock_QuotaService.go
@@ -3390,20 +3390,31 @@ func (_c *MockQuotaService_UpdateQuotaPlan_Call) RunAndReturn(run func(ctx conte
 }
 
 // UpdateUserQuotaConfig provides a mock function for the type MockQuotaService
-func (_mock *MockQuotaService) UpdateUserQuotaConfig(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) error {
+func (_mock *MockQuotaService) UpdateUserQuotaConfig(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) (*UserQuotaConfig, error) {
 	ret := _mock.Called(ctx, userID, update)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUserQuotaConfig")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, *UserQuotaConfigUpdate) error); ok {
+	var r0 *UserQuotaConfig
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, *UserQuotaConfigUpdate) (*UserQuotaConfig, error)); ok {
+		return returnFunc(ctx, userID, update)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, *UserQuotaConfigUpdate) *UserQuotaConfig); ok {
 		r0 = returnFunc(ctx, userID, update)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*UserQuotaConfig)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, *UserQuotaConfigUpdate) error); ok {
+		r1 = returnFunc(ctx, userID, update)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockQuotaService_UpdateUserQuotaConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateUserQuotaConfig'
@@ -3442,12 +3453,12 @@ func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) Return(err error) *MockQuotaService_UpdateUserQuotaConfig_Call {
-	_c.Call.Return(err)
+func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) Return(v *UserQuotaConfig, err error) *MockQuotaService_UpdateUserQuotaConfig_Call {
+	_c.Call.Return(v, err)
 	return _c
 }
 
-func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) RunAndReturn(run func(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) error) *MockQuotaService_UpdateUserQuotaConfig_Call {
+func (_c *MockQuotaService_UpdateUserQuotaConfig_Call) RunAndReturn(run func(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) (*UserQuotaConfig, error)) *MockQuotaService_UpdateUserQuotaConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/quota.go
+++ b/core/quota.go
@@ -49,7 +49,7 @@ type QuotaService interface {
 
 	// User Quota Config Management
 	ListUserQuotaConfigs(ctx context.Context, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*UserQuotaConfig, int64, error)
-	UpdateUserQuotaConfig(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) error
+	UpdateUserQuotaConfig(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) (*UserQuotaConfig, error)
 	ResetUserQuotaPlan(ctx context.Context, userID uint) error
 
 	// Allowance Management (for ALLOWANCE policy)

--- a/core/quota.go
+++ b/core/quota.go
@@ -47,6 +47,11 @@ type QuotaService interface {
 	AssignUserToPlan(ctx context.Context, userID uint, planID uint) error
 	RemoveUserFromPlan(ctx context.Context, userID uint) error
 
+	// User Quota Config Management
+	ListUserQuotaConfigs(ctx context.Context, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*UserQuotaConfig, int64, error)
+	UpdateUserQuotaConfig(ctx context.Context, userID uint, update *UserQuotaConfigUpdate) error
+	ResetUserQuotaPlan(ctx context.Context, userID uint) error
+
 	// Allowance Management (for ALLOWANCE policy)
 	AddAllowance(ctx context.Context, userID uint, storage, upload, download uint64) error
 	AddBonusAllowance(ctx context.Context, userID uint, storage, upload, download uint64) error

--- a/core/types.go
+++ b/core/types.go
@@ -156,3 +156,17 @@ type SystemStats struct {
 	TotalUsageBytes uint64 `json:"total_usage_bytes"`
 }
 
+// UserQuotaConfigUpdate represents the fields that can be updated for a user's quota config
+type UserQuotaConfigUpdate struct {
+	EnforcementPolicy  *EnforcementPolicy `json:"enforcement_policy,omitempty"`
+	QuotaPlanID        *uint64            `json:"quota_plan_id,omitempty"`
+	StorageLimit       *int64             `json:"storage_limit,omitempty"`
+	UploadDailyLimit   *int64             `json:"upload_daily_limit,omitempty"`
+	DownloadDailyLimit *int64             `json:"download_daily_limit,omitempty"`
+	UploadTotalLimit   *int64             `json:"upload_total_limit,omitempty"`
+	DownloadTotalLimit *int64             `json:"download_total_limit,omitempty"`
+	StorageThreshold   *int64             `json:"storage_threshold,omitempty"`
+	UploadThreshold    *int64             `json:"upload_threshold,omitempty"`
+	DownloadThreshold  *int64             `json:"download_threshold,omitempty"`
+}
+

--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
@@ -98,6 +99,9 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 	// Create reusable schema for AllowanceGrantResponse
 	grantSchema := queryutil.NewSchemaProvider().ForType(&dto.AllowanceGrantResponse{})
 
+	// Create reusable schema for UserQuotaConfigResponse
+	userConfigSchema := queryutil.NewSchemaProvider().ForType(&dto.UserQuotaConfigResponse{})
+
 	return []router.Route{
 		// Quota Plan Management
 		e.newRoute(http.MethodGet, "/plans", e.handleListPlans,
@@ -142,6 +146,31 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 			router.WithDescription("Set a quota plan as the default for new users"),
 			router.WithTags("quota", "plans"),
 			router.WithPathParam("planID", "Numeric ID of the quota plan", ""),
+		),
+
+		// User Quota Config Management
+		e.newRoute(http.MethodGet, "/user-configs", e.handleListUserQuotaConfigs,
+			router.WithSummary("List user quota configs"),
+			router.WithDescription("Get a paginated list of user quota configurations with filtering and sorting"),
+			router.WithTags("quota", "user-configs"),
+			router.WithSchema(userConfigSchema),
+			router.WithFilterParamsFromSchema(userConfigSchema),
+			router.WithSuccessResponse(http.StatusOK, "List of user quota configs", router.WithJSONContent(&dto.UserQuotaConfigListResponse{})),
+		),
+		e.newRoute(http.MethodPut, "/user-configs/:userID", e.handleUpdateUserQuotaConfig,
+			router.WithSummary("Update user quota config"),
+			router.WithDescription("Update a user's quota configuration"),
+			router.WithTags("quota", "user-configs"),
+			router.WithPathParam("userID", "Numeric ID of the user", ""),
+			router.WithRequestBody(&dto.UserQuotaConfigUpdateRequest{}, "User quota config update", true),
+			router.WithSuccessResponse(http.StatusOK, "User quota config updated", router.WithJSONContent(&dto.UserQuotaConfigResponse{})),
+		),
+		e.newRoute(http.MethodDelete, "/user-configs/:userID/plan", e.handleResetUserQuotaPlan,
+			router.WithSummary("Reset user quota plan"),
+			router.WithDescription("Remove a user's assigned quota plan (sets to NULL)"),
+			router.WithTags("quota", "user-configs"),
+			router.WithPathParam("userID", "Numeric ID of the user", ""),
+			router.WithSuccessResponse(http.StatusNoContent, "User quota plan reset successfully"),
 		),
 
 		// Allowance Management
@@ -389,6 +418,11 @@ func (e *QuotaAdminExtension) handleDeletePlan(c echo.Context) error {
 			apiErr := NewError(ErrKeyPlanNotFound, err)
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
+		// Check if the error indicates the plan is in use
+		if strings.Contains(err.Error(), "users assigned") {
+			apiErr := NewError(ErrKeyPlanInUse, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 		e.Logger().Error("failed to delete quota plan", zap.Error(err))
 		apiErr := NewError(ErrKeyPlanDeleteFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
@@ -413,6 +447,125 @@ func (e *QuotaAdminExtension) handleSetDefaultPlan(c echo.Context) error {
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
 		e.Logger().Error("failed to set default quota plan", zap.Error(err))
+		apiErr := NewError(ErrKeyConfigUpdateFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// User Quota Config Management Handlers
+func (e *QuotaAdminExtension) handleListUserQuotaConfigs(c echo.Context) error {
+	ctx := httputil.Context(c)
+
+	return queryutilHttp.ProcessListRequest(
+		c.Response(),
+		c.Request(),
+		"user-configs",
+		func(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*models.UserQuotaConfig, int64, error) {
+			return e.quotaService.ListUserQuotaConfigs(ctx.Request().Context(), filters, sorts, pagination)
+		},
+		func(config *models.UserQuotaConfig) dto.UserQuotaConfigResponse {
+			return dto.UserQuotaConfigResponse{
+				ID:                 config.ID,
+				UserID:             config.UserID,
+				EnforcementPolicy:  string(config.EnforcementPolicy),
+				QuotaPlanID:        config.QuotaPlanID,
+				StorageLimit:       config.StorageLimit,
+				UploadDailyLimit:   config.UploadDailyLimit,
+				DownloadDailyLimit: config.DownloadDailyLimit,
+				UploadTotalLimit:   config.UploadTotalLimit,
+				DownloadTotalLimit: config.DownloadTotalLimit,
+				StorageThreshold:   config.StorageThreshold,
+				UploadThreshold:    config.UploadThreshold,
+				DownloadThreshold:  config.DownloadThreshold,
+				CreatedAt:          config.CreatedAt,
+				UpdatedAt:          config.UpdatedAt,
+			}
+		},
+	)
+}
+
+func (e *QuotaAdminExtension) handleUpdateUserQuotaConfig(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	userID, err := parseUintParam(c, "userID")
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidRequestParameters, fmt.Errorf("invalid user ID: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	var req dto.UserQuotaConfigUpdateRequest
+	_, ok := httputil.DecodeAndValidateRequest[*dto.UserQuotaConfigUpdateRequest, *dto.UserQuotaConfigUpdateRequest](ctx, &req)
+	if !ok {
+		return nil
+	}
+
+	// Convert request to core update struct
+	update := &quotaCore.UserQuotaConfigUpdate{}
+
+	if req.EnforcementPolicy != nil {
+		policy := quotaCore.EnforcementPolicy(*req.EnforcementPolicy)
+		update.EnforcementPolicy = &policy
+	}
+	if req.QuotaPlanID != nil {
+		update.QuotaPlanID = req.QuotaPlanID
+	}
+	if req.StorageLimit != nil {
+		update.StorageLimit = req.StorageLimit
+	}
+	if req.UploadDailyLimit != nil {
+		update.UploadDailyLimit = req.UploadDailyLimit
+	}
+	if req.DownloadDailyLimit != nil {
+		update.DownloadDailyLimit = req.DownloadDailyLimit
+	}
+	if req.UploadTotalLimit != nil {
+		update.UploadTotalLimit = req.UploadTotalLimit
+	}
+	if req.DownloadTotalLimit != nil {
+		update.DownloadTotalLimit = req.DownloadTotalLimit
+	}
+	if req.StorageThreshold != nil {
+		update.StorageThreshold = req.StorageThreshold
+	}
+	if req.UploadThreshold != nil {
+		update.UploadThreshold = req.UploadThreshold
+	}
+	if req.DownloadThreshold != nil {
+		update.DownloadThreshold = req.DownloadThreshold
+	}
+
+	if err := e.quotaService.UpdateUserQuotaConfig(reqCtx, userID, update); err != nil {
+		e.Logger().Error("failed to update user quota config", zap.Error(err))
+		apiErr := NewError(ErrKeyConfigUpdateFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	// Fetch the updated config to return
+	config, err := e.quotaService.GetQuotaConfig(reqCtx, userID)
+	if err != nil {
+		e.Logger().Error("failed to fetch updated user quota config", zap.Error(err))
+		apiErr := NewError(ErrKeyConfigFetchFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	return httputil.EncodeResponse(ctx, config, &dto.UserQuotaConfigResponse{})
+}
+
+func (e *QuotaAdminExtension) handleResetUserQuotaPlan(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	userID, err := parseUintParam(c, "userID")
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidRequestParameters, fmt.Errorf("invalid user ID: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if err := e.quotaService.ResetUserQuotaPlan(reqCtx, userID); err != nil {
+		e.Logger().Error("failed to reset user quota plan", zap.Error(err))
 		apiErr := NewError(ErrKeyConfigUpdateFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}

--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -505,49 +505,21 @@ func (e *QuotaAdminExtension) handleUpdateUserQuotaConfig(c echo.Context) error 
 	// Convert request to core update struct
 	update := &quotaCore.UserQuotaConfigUpdate{}
 
-	if req.EnforcementPolicy != nil {
-		policy := quotaCore.EnforcementPolicy(*req.EnforcementPolicy)
-		update.EnforcementPolicy = &policy
-	}
-	if req.QuotaPlanID != nil {
-		update.QuotaPlanID = req.QuotaPlanID
-	}
-	if req.StorageLimit != nil {
-		update.StorageLimit = req.StorageLimit
-	}
-	if req.UploadDailyLimit != nil {
-		update.UploadDailyLimit = req.UploadDailyLimit
-	}
-	if req.DownloadDailyLimit != nil {
-		update.DownloadDailyLimit = req.DownloadDailyLimit
-	}
-	if req.UploadTotalLimit != nil {
-		update.UploadTotalLimit = req.UploadTotalLimit
-	}
-	if req.DownloadTotalLimit != nil {
-		update.DownloadTotalLimit = req.DownloadTotalLimit
-	}
-	if req.StorageThreshold != nil {
-		update.StorageThreshold = req.StorageThreshold
-	}
-	if req.UploadThreshold != nil {
-		update.UploadThreshold = req.UploadThreshold
-	}
-	if req.DownloadThreshold != nil {
-		update.DownloadThreshold = req.DownloadThreshold
-	}
+	update.EnforcementPolicy = req.EnforcementPolicy
+	update.QuotaPlanID = req.QuotaPlanID
+	update.StorageLimit = req.StorageLimit
+	update.UploadDailyLimit = req.UploadDailyLimit
+	update.DownloadDailyLimit = req.DownloadDailyLimit
+	update.UploadTotalLimit = req.UploadTotalLimit
+	update.DownloadTotalLimit = req.DownloadTotalLimit
+	update.StorageThreshold = req.StorageThreshold
+	update.UploadThreshold = req.UploadThreshold
+	update.DownloadThreshold = req.DownloadThreshold
 
-	if err := e.quotaService.UpdateUserQuotaConfig(reqCtx, userID, update); err != nil {
+	config, err := e.quotaService.UpdateUserQuotaConfig(reqCtx, userID, update)
+	if err != nil {
 		e.Logger().Error("failed to update user quota config", zap.Error(err))
 		apiErr := NewError(ErrKeyConfigUpdateFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	// Fetch the updated config to return
-	config, err := e.quotaService.GetQuotaConfig(reqCtx, userID)
-	if err != nil {
-		e.Logger().Error("failed to fetch updated user quota config", zap.Error(err))
-		apiErr := NewError(ErrKeyConfigFetchFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/dto/admin_quota.go
+++ b/internal/api/dto/admin_quota.go
@@ -22,6 +22,11 @@ var (
 	_ httputil.DTORequest[*CleanupRequest] = (*CleanupRequest)(nil)
 	_ httputil.DTOValidator = (*QuotaConfigUpdateRequest)(nil)
 	_ httputil.DTORequest[*QuotaConfigUpdateRequest] = (*QuotaConfigUpdateRequest)(nil)
+	_ httputil.DTOValidator = (*UserQuotaConfigUpdateRequest)(nil)
+	_ httputil.DTORequest[*UserQuotaConfigUpdateRequest] = (*UserQuotaConfigUpdateRequest)(nil)
+	_ httputil.DTOValidator = (*UserQuotaConfigListRequest)(nil)
+	_ httputil.DTORequest[*UserQuotaConfigListRequest] = (*UserQuotaConfigListRequest)(nil)
+	_ httputil.DTOResponse[*models.UserQuotaConfig] = (*UserQuotaConfigResponse)(nil)
 )
 
 // QuotaPlanRequest describes a quota plan for creation/update
@@ -294,6 +299,107 @@ type ReconcileResponse struct {
 
 func (r ReconcileResponse) FromModel(_ ReconcileResponse) error {
 	return nil
+}
+
+// UserQuotaConfigResponse represents a user quota configuration
+// Note: Uses pointer for UserID to avoid gorm.Model embedding issues
+type UserQuotaConfigResponse struct {
+	ID                 uint      `json:"id"`
+	UserID             uint      `json:"user_id"`
+	EnforcementPolicy  string    `json:"enforcement_policy"`
+	QuotaPlanID        *uint64   `json:"quota_plan_id,omitempty"`
+	StorageLimit       *int64    `json:"storage_limit,omitempty"`
+	UploadDailyLimit   *int64    `json:"upload_daily_limit,omitempty"`
+	DownloadDailyLimit *int64    `json:"download_daily_limit,omitempty"`
+	UploadTotalLimit   *int64    `json:"upload_total_limit,omitempty"`
+	DownloadTotalLimit *int64    `json:"download_total_limit,omitempty"`
+	StorageThreshold   *int64    `json:"storage_threshold,omitempty"`
+	UploadThreshold    *int64    `json:"upload_threshold,omitempty"`
+	DownloadThreshold  *int64    `json:"download_threshold,omitempty"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+func (r *UserQuotaConfigResponse) FromModel(model *models.UserQuotaConfig) error {
+	if model == nil {
+		return nil
+	}
+	r.ID = model.ID
+	r.UserID = model.UserID
+	r.EnforcementPolicy = string(model.EnforcementPolicy)
+	r.QuotaPlanID = model.QuotaPlanID
+	r.StorageLimit = model.StorageLimit
+	r.UploadDailyLimit = model.UploadDailyLimit
+	r.DownloadDailyLimit = model.DownloadDailyLimit
+	r.UploadTotalLimit = model.UploadTotalLimit
+	r.DownloadTotalLimit = model.DownloadTotalLimit
+	r.StorageThreshold = model.StorageThreshold
+	r.UploadThreshold = model.UploadThreshold
+	r.DownloadThreshold = model.DownloadThreshold
+	r.CreatedAt = model.CreatedAt
+	r.UpdatedAt = model.UpdatedAt
+	return nil
+}
+
+// UserQuotaConfigListResponse is a swagger-only DTO that represents the paginated response for user quota configs.
+// It mirrors queryutil.Response[*dto.UserQuotaConfigResponse] for OpenAPI documentation.
+//
+// This struct exists due to a swagger documentation generation bug where queryutil.Response generics
+// are not getting detected properly as an array type. By providing a concrete struct, we ensure the
+// swagger docs correctly show the Configs field (mapped to "data" in JSON) as an array of UserQuotaConfigResponse items.
+//
+// Note: This struct is only used for swagger documentation, not for actual encoding.
+type UserQuotaConfigListResponse struct {
+	Configs []UserQuotaConfigResponse `json:"data"`
+	Total   int                       `json:"total"`
+}
+
+// UserQuotaConfigUpdateRequest represents a request to update a user's quota config
+type UserQuotaConfigUpdateRequest struct {
+	EnforcementPolicy  *string `json:"enforcement_policy,omitempty"`
+	QuotaPlanID        *uint64 `json:"quota_plan_id,omitempty"`
+	StorageLimit       *int64  `json:"storage_limit,omitempty"`
+	UploadDailyLimit   *int64  `json:"upload_daily_limit,omitempty"`
+	DownloadDailyLimit *int64  `json:"download_daily_limit,omitempty"`
+	UploadTotalLimit   *int64  `json:"upload_total_limit,omitempty"`
+	DownloadTotalLimit *int64  `json:"download_total_limit,omitempty"`
+	StorageThreshold   *int64  `json:"storage_threshold,omitempty"`
+	UploadThreshold    *int64  `json:"upload_threshold,omitempty"`
+	DownloadThreshold  *int64  `json:"download_threshold,omitempty"`
+}
+
+func (r *UserQuotaConfigUpdateRequest) Schema() *z.StructSchema {
+	return z.Struct(z.Shape{
+		"EnforcementPolicy":  config.ZogStringLike[models.EnforcementPolicy]().Optional(),
+		"QuotaPlanID":        z.Ptr(z.UintLike[uint64]()),
+		"StorageLimit":       z.Ptr(z.Int64().GTE(0)),
+		"UploadDailyLimit":   z.Ptr(z.Int64().GTE(0)),
+		"DownloadDailyLimit": z.Ptr(z.Int64().GTE(0)),
+		"UploadTotalLimit":   z.Ptr(z.Int64().GTE(0)),
+		"DownloadTotalLimit": z.Ptr(z.Int64().GTE(0)),
+		"StorageThreshold":   z.Ptr(z.Int64().GTE(0)),
+		"UploadThreshold":    z.Ptr(z.Int64().GTE(0)),
+		"DownloadThreshold":  z.Ptr(z.Int64().GTE(0)),
+	})
+}
+
+func (r *UserQuotaConfigUpdateRequest) ToModel() (*UserQuotaConfigUpdateRequest, error) {
+	return r, nil
+}
+
+// UserQuotaConfigListRequest represents query parameters for listing user quota configs
+type UserQuotaConfigListRequest struct {
+	PlanID *uint `query:"plan_id" json:"plan_id,omitempty"`
+}
+
+func (r *UserQuotaConfigListRequest) Schema() *z.StructSchema {
+	return z.Struct(z.Shape{
+		"PlanID": z.Ptr(z.UintLike[uint]()),
+	})
+}
+
+func (r *UserQuotaConfigListRequest) ToModel() (*UserQuotaConfigListRequest, error) {
+	return r, nil
 }
 
 // SystemStatsResponse represents system-wide quota statistics

--- a/internal/api/dto/admin_quota.go
+++ b/internal/api/dto/admin_quota.go
@@ -356,16 +356,16 @@ type UserQuotaConfigListResponse struct {
 
 // UserQuotaConfigUpdateRequest represents a request to update a user's quota config
 type UserQuotaConfigUpdateRequest struct {
-	EnforcementPolicy  *string `json:"enforcement_policy,omitempty"`
-	QuotaPlanID        *uint64 `json:"quota_plan_id,omitempty"`
-	StorageLimit       *int64  `json:"storage_limit,omitempty"`
-	UploadDailyLimit   *int64  `json:"upload_daily_limit,omitempty"`
-	DownloadDailyLimit *int64  `json:"download_daily_limit,omitempty"`
-	UploadTotalLimit   *int64  `json:"upload_total_limit,omitempty"`
-	DownloadTotalLimit *int64  `json:"download_total_limit,omitempty"`
-	StorageThreshold   *int64  `json:"storage_threshold,omitempty"`
-	UploadThreshold    *int64  `json:"upload_threshold,omitempty"`
-	DownloadThreshold  *int64  `json:"download_threshold,omitempty"`
+	EnforcementPolicy  *models.EnforcementPolicy `json:"enforcement_policy,omitempty"`
+	QuotaPlanID        *uint64                   `json:"quota_plan_id,omitempty"`
+	StorageLimit       *int64                    `json:"storage_limit,omitempty"`
+	UploadDailyLimit   *int64                    `json:"upload_daily_limit,omitempty"`
+	DownloadDailyLimit *int64                    `json:"download_daily_limit,omitempty"`
+	UploadTotalLimit   *int64                    `json:"upload_total_limit,omitempty"`
+	DownloadTotalLimit *int64                    `json:"download_total_limit,omitempty"`
+	StorageThreshold   *int64                    `json:"storage_threshold,omitempty"`
+	UploadThreshold    *int64                    `json:"upload_threshold,omitempty"`
+	DownloadThreshold  *int64                    `json:"download_threshold,omitempty"`
 }
 
 func (r *UserQuotaConfigUpdateRequest) Schema() *z.StructSchema {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -35,6 +35,7 @@ const (
 	ErrKeyCleanupFailed       core.ErrorType = "CLEANUP_FAILED"
 	ErrKeyConfigUpdateFailed  core.ErrorType = "CONFIG_UPDATE_FAILED"
 	ErrKeyConfigFetchFailed   core.ErrorType = "CONFIG_FETCH_FAILED"
+	ErrKeyPlanInUse         core.ErrorType = "PLAN_IN_USE"
 )
 
 // ErrorDetails represents the structured error response format
@@ -118,6 +119,7 @@ func init() {
 		ErrKeyCleanupFailed:       {Key: ErrKeyCleanupFailed, Message: "Failed to cleanup old records"},
 		ErrKeyConfigUpdateFailed:  {Key: ErrKeyConfigUpdateFailed, Message: "Failed to update system config"},
 		ErrKeyConfigFetchFailed:   {Key: ErrKeyConfigFetchFailed, Message: "Failed to fetch system config"},
+		ErrKeyPlanInUse:         {Key: ErrKeyPlanInUse, Message: "Cannot delete plan because it is assigned to users"},
 	})
 
 	core.MustRegisterErrorCodes(Namespace, map[core.ErrorType]int{
@@ -144,6 +146,7 @@ func init() {
 		ErrKeyCleanupFailed:       http.StatusInternalServerError,
 		ErrKeyConfigUpdateFailed:  http.StatusInternalServerError,
 		ErrKeyConfigFetchFailed:   http.StatusInternalServerError,
+		ErrKeyPlanInUse:         http.StatusConflict,
 	})
 }
 

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -708,17 +708,17 @@ func (s *QuotaServiceDefault) ListUserQuotaConfigs(ctx context.Context, filters 
 	return configs, total, nil
 }
 
-// UpdateUserQuotaConfig updates a user's quota configuration
-func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID uint, update *pluginCore.UserQuotaConfigUpdate) error {
+// UpdateUserQuotaConfig updates a user's quota configuration and returns the updated config
+func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID uint, update *pluginCore.UserQuotaConfigUpdate) (*models.UserQuotaConfig, error) {
 	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.UpdateUserQuotaConfig")
 	defer span.End()
 
 	if s.DB() == nil {
-		return fmt.Errorf("database not initialized")
+		return nil, fmt.Errorf("database not initialized")
 	}
 
 	if userID == 0 {
-		return fmt.Errorf("invalid user ID")
+		return nil, fmt.Errorf("invalid user ID")
 	}
 
 	// Build update map with only provided fields
@@ -756,8 +756,10 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 	}
 
 	if len(updates) == 0 {
-		return fmt.Errorf("no fields to update")
+		return nil, fmt.Errorf("no fields to update")
 	}
+
+	var updatedConfig models.UserQuotaConfig
 
 	// Ensure the user has a quota config first, then apply updates
 	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
@@ -771,12 +773,17 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 		}
 
 		// Apply the updates to the found/created config
-		return tx.Model(&config).Updates(updates)
+		if result = tx.Model(&config).Updates(updates); result.Error != nil {
+			return result
+		}
+
+		// Reload the config to return the updated state
+		return tx.Where("user_id = ?", userID).First(&updatedConfig)
 	}); err != nil {
-		return fmt.Errorf("failed to update user quota config: %w", err)
+		return nil, fmt.Errorf("failed to update user quota config: %w", err)
 	}
 
-	return nil
+	return &updatedConfig, nil
 }
 
 // ResetUserQuotaPlan resets a user's quota plan assignment to NULL

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -474,6 +474,18 @@ func (s *QuotaServiceDefault) DeleteQuotaPlan(ctx context.Context, planID uint) 
 		return fmt.Errorf("database not initialized")
 	}
 
+	// Check if any users are assigned to this plan
+	var assignedUserCount int64
+	if err := s.DB().WithContext(ctx).Model(&models.UserQuotaConfig{}).
+		Where("quota_plan_id = ?", planID).
+		Count(&assignedUserCount).Error; err != nil {
+		return fmt.Errorf("failed to check plan assignments: %w", err)
+	}
+
+	if assignedUserCount > 0 {
+		return fmt.Errorf("plan %d has %d users assigned, cannot delete", planID, assignedUserCount)
+	}
+
 	err := core.MetricTrack(
 		nil,
 		policies.PlanOperationsErr.WithLabelValues(policies.LabelPlanOperationDelete),
@@ -637,11 +649,7 @@ func (s *QuotaServiceDefault) AssignUserToPlan(ctx context.Context, userID uint,
 		}
 
 		// Update the user's quota config with the plan ID
-		if result = tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", planID); result.Error != nil {
-			return result
-		}
-
-		return nil
+		return tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", planID)
 	})
 
 }
@@ -664,6 +672,131 @@ func (s *QuotaServiceDefault) RemoveUserFromPlan(ctx context.Context, userID uin
 		return tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", nil)
 	}); err != nil {
 		return fmt.Errorf("failed to remove user from plan: %w", err)
+	}
+
+	return nil
+}
+
+// ListUserQuotaConfigs retrieves a paginated and filtered list of user quota configurations
+func (s *QuotaServiceDefault) ListUserQuotaConfigs(ctx context.Context, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*models.UserQuotaConfig, int64, error) {
+	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.ListUserQuotaConfigs")
+	defer span.End()
+
+	if s.DB() == nil {
+		return nil, 0, fmt.Errorf("database not initialized")
+	}
+
+	var configs []*models.UserQuotaConfig
+	var total int64
+
+	query := s.DB().WithContext(ctx).Model(&models.UserQuotaConfig{})
+
+	// Apply filters, sorts and pagination using queryutil helpers
+	query = queryutil.ApplyFilters(query, filters, nil)
+	query = queryutil.ApplySort(query, sorts)
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count user quota configs: %w", err)
+	}
+
+	query = queryutil.ApplyPagination(query, pagination)
+
+	if err := query.Find(&configs).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch user quota configs: %w", err)
+	}
+
+	return configs, total, nil
+}
+
+// UpdateUserQuotaConfig updates a user's quota configuration
+func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID uint, update *pluginCore.UserQuotaConfigUpdate) error {
+	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.UpdateUserQuotaConfig")
+	defer span.End()
+
+	if s.DB() == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if userID == 0 {
+		return fmt.Errorf("invalid user ID")
+	}
+
+	// Build update map with only provided fields
+	updates := make(map[string]interface{})
+
+	if update.EnforcementPolicy != nil {
+		updates["enforcement_policy"] = *update.EnforcementPolicy
+	}
+	if update.QuotaPlanID != nil {
+		updates["quota_plan_id"] = *update.QuotaPlanID
+	}
+	if update.StorageLimit != nil {
+		updates["storage_limit"] = update.StorageLimit
+	}
+	if update.UploadDailyLimit != nil {
+		updates["upload_daily_limit"] = update.UploadDailyLimit
+	}
+	if update.DownloadDailyLimit != nil {
+		updates["download_daily_limit"] = update.DownloadDailyLimit
+	}
+	if update.UploadTotalLimit != nil {
+		updates["upload_total_limit"] = update.UploadTotalLimit
+	}
+	if update.DownloadTotalLimit != nil {
+		updates["download_total_limit"] = update.DownloadTotalLimit
+	}
+	if update.StorageThreshold != nil {
+		updates["storage_threshold"] = update.StorageThreshold
+	}
+	if update.UploadThreshold != nil {
+		updates["upload_threshold"] = update.UploadThreshold
+	}
+	if update.DownloadThreshold != nil {
+		updates["download_threshold"] = update.DownloadThreshold
+	}
+
+	if len(updates) == 0 {
+		return fmt.Errorf("no fields to update")
+	}
+
+	// Ensure the user has a quota config first, then apply updates
+	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		var config models.UserQuotaConfig
+		result := tx.Where("user_id = ?", userID).FirstOrCreate(&config, &models.UserQuotaConfig{
+			UserID:            userID,
+			EnforcementPolicy: models.EnforcementPolicyHardLimits,
+		})
+		if result.Error != nil {
+			return result
+		}
+
+		// Apply the updates to the found/created config
+		return tx.Model(&config).Updates(updates)
+	}); err != nil {
+		return fmt.Errorf("failed to update user quota config: %w", err)
+	}
+
+	return nil
+}
+
+// ResetUserQuotaPlan resets a user's quota plan assignment to NULL
+func (s *QuotaServiceDefault) ResetUserQuotaPlan(ctx context.Context, userID uint) error {
+	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.ResetUserQuotaPlan")
+	defer span.End()
+
+	if s.DB() == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if userID == 0 {
+		return fmt.Errorf("invalid user ID")
+	}
+
+	// Update the quota config to remove the plan ID
+	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", nil)
+	}); err != nil {
+		return fmt.Errorf("failed to reset user quota plan: %w", err)
 	}
 
 	return nil

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -17,6 +16,7 @@ import (
 	pluginModels "go.lumeweb.com/portal-plugin-quota/internal/db/models"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/queryutil"
 	"gorm.io/gorm"
 )
 
@@ -1193,6 +1193,363 @@ func TestUpdateAllowanceGrant_PreservesUserID(t *testing.T) {
 		assert.Equal(t, userID, updatedGrant.UserID, "UserID should not be overwritten")
 		assert.Equal(t, uint64(20000), updatedGrant.Bytes, "Bytes should be updated")
 
+	}, testOptions())
+}
+
+// TestDeleteQuotaPlan_WithAssignedUsers_PreventsDeletion tests that deleting a plan
+// with assigned users fails with an appropriate error.
+func TestDeleteQuotaPlan_WithAssignedUsers_PreventsDeletion(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a quota plan
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan For Deletion",
+			Description:        "Plan to test deletion prevention",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan.IsActive = true
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+		require.NotZero(t, plan.ID)
+
+		// Assign a user to this plan
+		userID := uint(99999)
+		err = quotaService.AssignUserToPlan(ctx, userID, plan.ID)
+		require.NoError(t, err)
+
+		// Act - Try to delete the plan
+		err = quotaService.DeleteQuotaPlan(ctx, plan.ID)
+
+		// Assert - Deletion should fail
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "users assigned")
+
+		// Verify the plan still exists
+		existingPlan, err := quotaService.GetQuotaPlan(ctx, plan.ID)
+		require.NoError(t, err)
+		assert.NotNil(t, existingPlan)
+	}, testOptions())
+}
+
+// TestDeleteQuotaPlan_WithoutAssignedUsers_Succeeds tests that deleting a plan
+// with no assigned users succeeds.
+func TestDeleteQuotaPlan_WithoutAssignedUsers_Succeeds(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a quota plan
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan For Deletion Success",
+			Description:        "Plan to test successful deletion",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan.IsActive = true
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+		require.NotZero(t, plan.ID)
+		planID := plan.ID
+
+		// Act - Delete the plan (no users assigned)
+		err = quotaService.DeleteQuotaPlan(ctx, planID)
+
+		// Assert - Deletion should succeed
+		require.NoError(t, err)
+
+		// Verify the plan no longer exists
+		_, err = quotaService.GetQuotaPlan(ctx, planID)
+		require.Error(t, err)
+	}, testOptions())
+}
+
+// TestDeleteQuotaPlan_AfterRemovingUsers_Succeeds tests that a plan can be deleted
+// after all users have been removed from it.
+func TestDeleteQuotaPlan_AfterRemovingUsers_Succeeds(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a quota plan
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan Remove Then Delete",
+			Description:        "Plan to test removal then deletion",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan.IsActive = true
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+		require.NotZero(t, plan.ID)
+
+		// Assign a user to this plan
+		userID := uint(88888)
+		err = quotaService.AssignUserToPlan(ctx, userID, plan.ID)
+		require.NoError(t, err)
+
+		// Try to delete - should fail
+		err = quotaService.DeleteQuotaPlan(ctx, plan.ID)
+		require.Error(t, err)
+
+		// Remove user from plan
+		err = quotaService.RemoveUserFromPlan(ctx, userID)
+		require.NoError(t, err)
+
+		// Act - Now deletion should succeed
+		err = quotaService.DeleteQuotaPlan(ctx, plan.ID)
+
+		// Assert - Deletion should succeed
+		require.NoError(t, err)
+	}, testOptions())
+}
+
+// TestListUserQuotaConfigs_ReturnsConfigs tests that ListUserQuotaConfigs returns
+// user quota configurations with pagination.
+func TestListUserQuotaConfigs_ReturnsConfigs(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a plan and assign users
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan For List",
+			Description:        "Plan for testing list configs",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan.IsActive = true
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+
+		// Assign multiple users to the plan
+		for i := uint(1); i <= 3; i++ {
+			err = quotaService.AssignUserToPlan(ctx, i+1000, plan.ID)
+			require.NoError(t, err)
+		}
+
+		// Act - List user configs
+		pagination, err := queryutil.NewPagination(0, 10)
+		require.NoError(t, err)
+		configs, total, err := quotaService.ListUserQuotaConfigs(ctx, nil, nil, pagination)
+
+		// Assert
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, total, int64(3))
+		assert.GreaterOrEqual(t, len(configs), 3)
+	}, testOptions())
+}
+
+// TestListUserQuotaConfigs_WithPlanFilter_FiltersByPlan tests that ListUserQuotaConfigs
+// correctly filters by plan ID.
+func TestListUserQuotaConfigs_WithPlanFilter_FiltersByPlan(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create two plans
+		plan1 := &pluginModels.QuotaPlan{
+			Name:               "Test Plan 1",
+			Description:        "First plan",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan1.IsActive = true
+
+		plan2 := &pluginModels.QuotaPlan{
+			Name:               "Test Plan 2",
+			Description:        "Second plan",
+			StorageLimit:       5368709120,
+			UploadDailyLimit:   52428800,
+			DownloadDailyLimit: 262144000,
+			UploadTotalLimit:   5368709120,
+			DownloadTotalLimit: 2684354560,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan2.IsActive = true
+
+		err := quotaService.CreateQuotaPlan(ctx, plan1)
+		require.NoError(t, err)
+		err = quotaService.CreateQuotaPlan(ctx, plan2)
+		require.NoError(t, err)
+
+		// Assign users to different plans
+		err = quotaService.AssignUserToPlan(ctx, 2001, plan1.ID)
+		require.NoError(t, err)
+		err = quotaService.AssignUserToPlan(ctx, 2002, plan1.ID)
+		require.NoError(t, err)
+		err = quotaService.AssignUserToPlan(ctx, 2003, plan2.ID)
+		require.NoError(t, err)
+
+		// Create filter for plan1 using queryutil.Equal
+		planIDUint := uint64(plan1.ID)
+		filters := []queryutil.CrudFilter{queryutil.Equal("quota_plan_id", planIDUint)}
+
+		// Act - List configs filtered by plan1
+		pagination, err := queryutil.NewPagination(0, 10)
+		require.NoError(t, err)
+		configs, total, err := quotaService.ListUserQuotaConfigs(ctx, filters, nil, pagination)
+
+		// Assert
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total)
+		assert.Len(t, configs, 2)
+
+		// Verify all returned configs belong to plan1
+		for _, config := range configs {
+			require.NotNil(t, config.QuotaPlanID)
+			assert.Equal(t, uint64(plan1.ID), *config.QuotaPlanID)
+		}
+	}, testOptions())
+}
+
+// TestUpdateUserQuotaConfig_UpdatesFields tests that UpdateUserQuotaConfig correctly
+// updates the specified fields.
+func TestUpdateUserQuotaConfig_UpdatesFields(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create initial config for user
+		userID := uint(3001)
+		initialConfig := &pluginCore.UserQuotaConfig{
+			UserID:            userID,
+			EnforcementPolicy: pluginModels.EnforcementPolicyHardLimits,
+		}
+		err := quotaService.SetQuotaConfig(ctx, userID, initialConfig)
+		require.NoError(t, err)
+
+		// Prepare update
+		newStorageLimit := int64(999999999)
+		newPolicy := pluginModels.EnforcementPolicyThreshold
+		update := &pluginCore.UserQuotaConfigUpdate{
+			StorageLimit:      &newStorageLimit,
+			EnforcementPolicy: &newPolicy,
+		}
+
+		// Act - Update the config
+		err = quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+
+		// Assert
+		require.NoError(t, err)
+
+		// Verify the update
+		updatedConfig, err := quotaService.GetQuotaConfig(ctx, userID)
+		require.NoError(t, err)
+		assert.Equal(t, newStorageLimit, *updatedConfig.StorageLimit)
+		assert.Equal(t, newPolicy, updatedConfig.EnforcementPolicy)
+	}, testOptions())
+}
+
+// TestUpdateUserQuotaConfig_NoFields_ReturnsError tests that UpdateUserQuotaConfig
+// returns an error when no fields are provided to update.
+func TestUpdateUserQuotaConfig_NoFields_ReturnsError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create initial config
+		userID := uint(3002)
+		initialConfig := &pluginCore.UserQuotaConfig{
+			UserID:            userID,
+			EnforcementPolicy: pluginModels.EnforcementPolicyHardLimits,
+		}
+		err := quotaService.SetQuotaConfig(ctx, userID, initialConfig)
+		require.NoError(t, err)
+
+		// Act - Update with empty update (no fields)
+		update := &pluginCore.UserQuotaConfigUpdate{}
+		err = quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+
+		// Assert
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no fields to update")
+	}, testOptions())
+}
+
+// TestResetUserQuotaPlan_SetsPlanToNull tests that ResetUserQuotaPlan correctly
+// sets the quota_plan_id to NULL.
+func TestResetUserQuotaPlan_SetsPlanToNull(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a plan and assign user
+		plan := &pluginModels.QuotaPlan{
+			Name:               "Test Plan For Reset",
+			Description:        "Plan for testing reset",
+			StorageLimit:       10737418240,
+			UploadDailyLimit:   104857600,
+			DownloadDailyLimit: 524288000,
+			UploadTotalLimit:   10737418240,
+			DownloadTotalLimit: 5368709120,
+			IsDefault:          false,
+			IsActive:           new(bool),
+		}
+		*plan.IsActive = true
+
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+
+		userID := uint(4001)
+		err = quotaService.AssignUserToPlan(ctx, userID, plan.ID)
+		require.NoError(t, err)
+
+		// Verify user is assigned
+		config, err := quotaService.GetQuotaConfig(ctx, userID)
+		require.NoError(t, err)
+		require.NotNil(t, config.QuotaPlanID)
+		assert.Equal(t, uint64(plan.ID), *config.QuotaPlanID)
+
+		// Act - Reset the plan
+		err = quotaService.ResetUserQuotaPlan(ctx, userID)
+
+		// Assert
+		require.NoError(t, err)
+
+		// Verify plan is now NULL
+		config, err = quotaService.GetQuotaConfig(ctx, userID)
+		require.NoError(t, err)
+		assert.Nil(t, config.QuotaPlanID)
+	}, testOptions())
+}
+
+// TestResetUserQuotaPlan_NonExistentUser_NoError tests that ResetUserQuotaPlan
+// doesn't error when the user doesn't exist (no-op).
+func TestResetUserQuotaPlan_NonExistentUser_NoError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Act - Reset plan for non-existent user
+		nonExistentUserID := uint(999999)
+		err := quotaService.ResetUserQuotaPlan(ctx, nonExistentUserID)
+
+		// Assert - Should not error (no-op)
+		require.NoError(t, err)
 	}, testOptions())
 }
 

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -1454,14 +1454,11 @@ func TestUpdateUserQuotaConfig_UpdatesFields(t *testing.T) {
 		}
 
 		// Act - Update the config
-		err = quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+		updatedConfig, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update)
 
 		// Assert
 		require.NoError(t, err)
-
-		// Verify the update
-		updatedConfig, err := quotaService.GetQuotaConfig(ctx, userID)
-		require.NoError(t, err)
+		require.NotNil(t, updatedConfig)
 		assert.Equal(t, newStorageLimit, *updatedConfig.StorageLimit)
 		assert.Equal(t, newPolicy, updatedConfig.EnforcementPolicy)
 	}, testOptions())
@@ -1484,10 +1481,11 @@ func TestUpdateUserQuotaConfig_NoFields_ReturnsError(t *testing.T) {
 
 		// Act - Update with empty update (no fields)
 		update := &pluginCore.UserQuotaConfigUpdate{}
-		err = quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+		updatedConfig, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update)
 
 		// Assert
 		require.Error(t, err)
+		require.Nil(t, updatedConfig)
 		assert.Contains(t, err.Error(), "no fields to update")
 	}, testOptions())
 }


### PR DESCRIPTION
- Add orphan prevention for plan deletion with assigned users
- Add ListUserQuotaConfigs with queryutil filtering support
- Add UpdateUserQuotaConfig for direct user config updates
- Add ResetUserQuotaPlan to remove plan assignments
- Add comprehensive tests for new functionality

---

<!-- kody-pr-summary:start -->
 This pull request introduces administrative APIs for managing individual user quota configurations. The changes enable administrators to view, update, and reset user-specific quota settings while preventing accidental deletion of quota plans that are currently assigned to users.

**Key Changes:**

1. **New User Quota Config Management APIs** - Added three new admin endpoints:
   - `GET /user-configs` - Lists user quota configurations with filtering, sorting, and pagination support
   - `PUT /user-configs/:userID` - Updates specific fields of a user's quota configuration (enforcement policy, limits, thresholds, and plan assignment)
   - `DELETE /user-configs/:userID/plan` - Removes a user's assigned quota plan (sets to NULL)

2. **Plan Deletion Protection** - Modified plan deletion logic to prevent removing quota plans that have users assigned to them, returning a conflict error when attempting to delete in-use plans.

3. **Data Transfer Objects** - Added request/response DTOs for user quota configurations with validation schemas for update operations, supporting partial updates where only provided fields are modified.

4. **Core Service Interface** - Extended the `QuotaService` interface with three new methods: `ListUserQuotaConfigs`, `UpdateUserQuotaConfig`, and `ResetUserQuotaPlan`, with full mock implementations for testing.

5. **Comprehensive Test Coverage** - Added tests verifying plan deletion constraints, user config listing with filters, field-level updates, and plan reset functionality.
<!-- kody-pr-summary:end -->