### PR TITLE
fix: add missing swagger success response to /plans/:planID/default endpoint

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -146,6 +146,7 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 			router.WithDescription("Set a quota plan as the default for new users"),
 			router.WithTags("quota", "plans"),
 			router.WithPathParam("planID", "Numeric ID of the quota plan", ""),
+			router.WithSuccessResponse(http.StatusNoContent, "Default plan set successfully"),
 		),
 
 		// User Quota Config Management


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 This pull request adds the missing Swagger/OpenAPI success response documentation to the `PUT /plans/:planID/default` endpoint. 

The change ensures the API specification correctly documents that the endpoint returns HTTP 204 (No Content) with the message "Default plan set successfully" when a quota plan is successfully set as the default for new users. This fixes the API documentation to accurately reflect the endpoint's behavior for client integrations and automated documentation generation.
<!-- kody-pr-summary:end -->