### PR TITLE
fix: remove default 200 ErrorResponse from DELETE/204 endpoints

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -139,6 +139,7 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 			router.WithDescription("Delete a quota plan by ID"),
 			router.WithTags("quota", "plans"),
 			router.WithPathParam("planID", "Numeric ID of the quota plan", ""),
+			router.WithoutDefaultSuccessResponse(),
 			router.WithSuccessResponse(http.StatusNoContent, "Plan deleted successfully"),
 		),
 		e.newRoute(http.MethodPost, "/plans/:planID/default", e.handleSetDefaultPlan,
@@ -146,6 +147,7 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 			router.WithDescription("Set a quota plan as the default for new users"),
 			router.WithTags("quota", "plans"),
 			router.WithPathParam("planID", "Numeric ID of the quota plan", ""),
+			router.WithoutDefaultSuccessResponse(),
 			router.WithSuccessResponse(http.StatusNoContent, "Default plan set successfully"),
 		),
 
@@ -171,6 +173,7 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 			router.WithDescription("Remove a user's assigned quota plan (sets to NULL)"),
 			router.WithTags("quota", "user-configs"),
 			router.WithPathParam("userID", "Numeric ID of the user", ""),
+			router.WithoutDefaultSuccessResponse(),
 			router.WithSuccessResponse(http.StatusNoContent, "User quota plan reset successfully"),
 		),
 
@@ -203,6 +206,7 @@ func (e *QuotaAdminExtension) buildRoutes() []router.Route {
 			router.WithDescription("Deactivate an allowance grant"),
 			router.WithTags("quota", "grants"),
 			router.WithPathParam("grantID", "Numeric ID of the allowance grant", ""),
+			router.WithoutDefaultSuccessResponse(),
 			router.WithSuccessResponse(http.StatusNoContent, "Grant deactivated"),
 		),
 


### PR DESCRIPTION
Add WithoutDefaultSuccessResponse() to all endpoints that return 204 NoContent to prevent portal router from adding default 200 OK with ErrorResponse schema.

Fixes swagger documentation for:
- DELETE /plans/:planID
- POST /plans/:planID/default
- DELETE /user-configs/:userID/plan
- DELETE /allowances/:grantID

---

<!-- kody-pr-summary:start -->
 Fixes incorrect API documentation generation for endpoints that return HTTP 204 (No Content) by removing default 200 success responses from the route specifications.

**Changes:**
- Added `router.WithoutDefaultSuccessResponse()` to four admin quota management endpoints that return 204 No Content:
  - DELETE `/plans/:planID` (Delete quota plan)
  - POST `/plans/:planID/default` (Set default quota plan)
  - DELETE `/users/:userID/plan` (Remove user's assigned plan)
  - POST `/grants/:grantID/deactivate` (Deactivate allowance grant)

**Impact:**
Ensures accurate OpenAPI/Swagger documentation by preventing the inclusion of default 200 OK response schemas for endpoints that actually return empty 204 No Content responses upon successful completion. This eliminates API specification inconsistencies between documented response schemas and actual endpoint behavior.
<!-- kody-pr-summary:end -->