### PR TITLE
fix: resolve Zog type cast error in UserQuotaConfigUpdateRequest

### DIFF
--- a/internal/api/dto/admin_quota.go
+++ b/internal/api/dto/admin_quota.go
@@ -375,7 +375,7 @@ type UserQuotaConfigUpdateRequest struct {
 
 func (r *UserQuotaConfigUpdateRequest) Schema() *z.StructSchema {
 	return z.Struct(z.Shape{
-		"EnforcementPolicy":  config.ZogStringLike[models.EnforcementPolicy]().Optional(),
+		"EnforcementPolicy":  z.Ptr(config.ZogStringLike[models.EnforcementPolicy]()),
 		"QuotaPlanID":        z.Ptr(z.UintLike[uint64]()),
 		"WindowType":         z.Ptr(z.String()),
 		"WindowDuration":     z.Ptr(z.Int64()),


### PR DESCRIPTION
Fix Zog schema validation panic caused by type mismatch between EnforcementPolicy field (*models.EnforcementPolicy) and schema (ZogStringLike without Ptr wrapper). Schema now correctly uses z.Ptr() to match pointer field type.

---

<!-- kody-pr-summary:start -->
 Fixes a Zog validation type cast error in the `UserQuotaConfigUpdateRequest` schema by changing the `EnforcementPolicy` field from `.Optional()` to `z.Ptr()`. This ensures proper validation handling for optional enforcement policy values when processing user quota configuration updates, resolving runtime validation failures in the quota management API.
<!-- kody-pr-summary:end -->