### PR TITLE
fix: add STORAGE_ADD mock expectations and make lock fields atomic

### DIFF
--- a/internal/api/quota_extension_test.go
+++ b/internal/api/quota_extension_test.go
@@ -233,7 +233,7 @@ func TestHandleQuotaStatus_HardLimitsPolicy(t *testing.T) {
 		mockUsageManager := quotaCore.NewMockUsageManager(t)
 		quotaSvc.EXPECT().GetUsageManager().Return(mockUsageManager)
 		
-		// Mock window-based usage queries for upload and download limits
+		// Mock window-based usage queries for upload, download, and storage limits
 		now := time.Now()
 		windowStart := now.Add(-30 * 24 * time.Hour)
 		
@@ -242,6 +242,9 @@ func TestHandleQuotaStatus_HardLimitsPolicy(t *testing.T) {
 		
 		mockUsageManager.EXPECT().GetUsageForWindow(mock.Anything, uint(1), quotaCore.UsageTypeDownload, mock.AnythingOfType("core.LimitWindow")).
 			Return(uint64(units.MiB*150), windowStart, now, nil).Once()
+
+		mockUsageManager.EXPECT().GetUsageForWindow(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd, mock.AnythingOfType("core.LimitWindow")).
+			Return(uint64(units.MiB*200), windowStart, now, nil).Once()
 
 		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
 
@@ -302,7 +305,7 @@ func TestHandleQuotaStatus_ThresholdPolicy(t *testing.T) {
 		mockUsageManager := quotaCore.NewMockUsageManager(t)
 		quotaSvc.EXPECT().GetUsageManager().Return(mockUsageManager)
 		
-		// Mock window-based usage queries for upload and download limits
+		// Mock window-based usage queries for upload, download, and storage limits
 		now := time.Now()
 		windowStart := now.Add(-30 * 24 * time.Hour)
 		
@@ -311,6 +314,9 @@ func TestHandleQuotaStatus_ThresholdPolicy(t *testing.T) {
 		
 		mockUsageManager.EXPECT().GetUsageForWindow(mock.Anything, uint(1), quotaCore.UsageTypeDownload, mock.AnythingOfType("core.LimitWindow")).
 			Return(uint64(units.MiB*450), windowStart, now, nil).Once()
+
+		mockUsageManager.EXPECT().GetUsageForWindow(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd, mock.AnythingOfType("core.LimitWindow")).
+			Return(uint64(units.MiB*100), windowStart, now, nil).Once()
 
 		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
 

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.lumeweb.com/portal/core"
@@ -29,7 +30,7 @@ type LockManagerDefault struct {
 // It wraps sync.Mutex and tracks the number of waiters.
 type userLock struct {
 	mu      sync.Mutex
-	waiters int32
+	waiters int64
 }
 
 // NewLockManager creates a new LockManager instance.
@@ -76,7 +77,7 @@ func (lm *LockManagerDefault) acquireLock(ctx context.Context, ul *userLock) (*d
 func (lm *LockManagerDefault) acquireWithSetup(ctx context.Context, userID uint, timeoutCtx *context.Context) (*defaultLock, error) {
 	// Get or create the user lock
 	ul := lm.getUserLock(userID)
-	ul.waiters++
+	atomic.AddInt64(&ul.waiters, 1)
 
 	// Choose the context for acquisition
 	acquireCtx := ctx
@@ -88,8 +89,7 @@ func (lm *LockManagerDefault) acquireWithSetup(ctx context.Context, userID uint,
 	if err != nil {
 		// Decrement waiters and cleanup on failure
 		lm.mu.Lock()
-		ul.waiters--
-		if ul.waiters <= 0 {
+		if atomic.AddInt64(&ul.waiters, -1) <= 0 {
 			delete(lm.locks, userID)
 		}
 		lm.mu.Unlock()
@@ -161,7 +161,7 @@ func (lm *LockManagerDefault) TryAcquireLock(ctx context.Context, userID uint) (
 
 	// Get or create the user lock
 	ul := lm.getUserLock(userID)
-	ul.waiters++
+	atomic.AddInt64(&ul.waiters, 1)
 
 	// Try to lock without blocking
 	if ul.mu.TryLock() {
@@ -175,9 +175,8 @@ func (lm *LockManagerDefault) TryAcquireLock(ctx context.Context, userID uint) (
 	// Decrement waiters since we didn't acquire the lock
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
-	ul.waiters--
 	// Clean up if no waiters remain
-	if ul.waiters <= 0 {
+	if atomic.AddInt64(&ul.waiters, -1) <= 0 {
 		delete(lm.locks, userID)
 	}
 
@@ -188,24 +187,16 @@ func (lm *LockManagerDefault) TryAcquireLock(ctx context.Context, userID uint) (
 // getUserLock gets or creates a lock for the specified user ID.
 // This is safe for concurrent access.
 func (lm *LockManagerDefault) getUserLock(userID uint) *userLock {
-	lm.mu.RLock()
-	ul, exists := lm.locks[userID]
-	lm.mu.RUnlock()
-
-	if exists {
-		return ul
-	}
-
-	// Create a new lock if it doesn't exist
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
-	// Double-check after acquiring write lock
+	// Check if lock already exists
 	if ul, exists := lm.locks[userID]; exists {
 		return ul
 	}
 
-	ul = &userLock{}
+	// Create a new lock if it doesn't exist
+	ul := &userLock{}
 	lm.locks[userID] = ul
 	return ul
 }
@@ -221,10 +212,8 @@ func (lm *LockManagerDefault) cleanupLock(userID uint) {
 		return
 	}
 
-	ul.waiters--
-
 	// Only remove if there are no waiters
-	if ul.waiters <= 0 {
+	if atomic.AddInt64(&ul.waiters, -1) <= 0 {
 		delete(lm.locks, userID)
 	}
 }
@@ -232,19 +221,18 @@ func (lm *LockManagerDefault) cleanupLock(userID uint) {
 // defaultLock implements the Lock interface with a cleanup callback.
 type defaultLock struct {
 	mu        *sync.Mutex
-	released  bool
+	released  int32
 	onRelease func()
 }
 
 // Release releases the lock.
 // Multiple calls to Release are safe - subsequent calls are no-ops.
 func (l *defaultLock) Release() {
-	if l.released {
+	if !atomic.CompareAndSwapInt32(&l.released, 0, 1) {
 		return
 	}
 
 	l.mu.Unlock()
-	l.released = true
 
 	if l.onRelease != nil {
 		l.onRelease()


### PR DESCRIPTION
- Add STORAGE\_ADD mock expectations to TestHandleQuotaStatus tests
- Change waiters counter to int64 with atomic operations
- Change released flag to int32 with atomic operations
- Simplify getUserLock to avoid race conditions

* `develop` <!-- branch-stack -->
  - **fix: add STORAGE\_ADD mock expectations and make lock fields atomic** :point\_left:


---

<!-- kody-pr-summary:start -->
Based on the code changes, this pull request addresses two distinct issues:

**1. Fixes Test Failures for Quota Status API**
Adds missing mock expectations for `STORAGE_ADD` usage type queries in the quota status handler tests. The test functions `TestHandleQuotaStatus_HardLimitsPolicy` and `TestHandleQuotaStatus_ThresholdPolicy` now properly mock window-based usage queries for storage limits alongside the existing upload and download limit mocks, ensuring the tests accurately reflect the full quota checking behavior.

**2. Resolves Race Conditions in Lock Management**
Converts the `waiters` counter and `released` flag in the user lock system from regular int/bool fields to atomic operations (`int64` with `atomic.AddInt64` and `int32` with `atomic.CompareAndSwapInt32`). This eliminates potential race conditions during concurrent lock acquisition and release operations, ensuring thread-safe access to shared lock state in high-concurrency scenarios. Additionally simplifies the `getUserLock` method by removing the redundant double-checked locking pattern.
<!-- kody-pr-summary:end -->