### PR TITLE
refactor(quota): make reservation release and usage recording atomic

### DIFF
--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -2,7 +2,6 @@ package lock
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -42,11 +41,10 @@ func NewLockManager(ctx core.Context) LockManager {
 	}
 }
 
-// validateUserID validates the user ID and returns an error if invalid.
+// validateUserID validates the user ID. Returns no-op for userID 0 (anonymous operations).
 func (lm *LockManagerDefault) validateUserID(userID uint) error {
 	if userID == 0 {
-		lm.logger.Error("Cannot acquire lock for invalid user ID", zap.Uint("user_id", userID))
-		return errors.New("invalid user ID: user ID must be greater than 0")
+		return nil // Anonymous operations use no-op lock
 	}
 	return nil
 }
@@ -109,15 +107,28 @@ func (lm *LockManagerDefault) acquireWithSetup(ctx context.Context, userID uint,
 	return lock, nil
 }
 
+// noOpLock is a no-operation lock implementation for anonymous operations.
+// It satisfies the Lock interface but does nothing, avoiding serialization
+// of anonymous operations while maintaining a consistent API.
+type noOpLock struct{}
+
+// Release is a no-op for the no-operation lock.
+func (n *noOpLock) Release() {
+	// No-op: anonymous operations don't need locking
+}
+
 // AcquireLock acquires a lock for the specified user ID.
 // If the lock is already held, this blocks until it becomes available
 // or the context is canceled.
+// For userID 0 (anonymous operations), returns a no-op lock to avoid
+// serializing all anonymous operations as a global mutex.
 func (lm *LockManagerDefault) AcquireLock(ctx context.Context, userID uint) (Lock, error) {
 	ctx, span := core.TraceMethod(ctx, "LockManagerDefault.AcquireLock")
 	defer span.End()
 
-	if err := lm.validateUserID(userID); err != nil {
-		return nil, err
+	// Return no-op lock for anonymous operations (userID == 0)
+	if userID == 0 {
+		return &noOpLock{}, nil
 	}
 
 	lm.logger.Debug("Acquiring lock for user", zap.Uint("user_id", userID))
@@ -127,12 +138,14 @@ func (lm *LockManagerDefault) AcquireLock(ctx context.Context, userID uint) (Loc
 
 // AcquireLockWithTimeout attempts to acquire a lock for the specified user ID
 // within the given timeout. If the timeout is exceeded, it returns ErrLockTimeout.
+// For userID 0 (anonymous operations), returns a no-op lock immediately.
 func (lm *LockManagerDefault) AcquireLockWithTimeout(ctx context.Context, userID uint, timeout Timeout) (Lock, error) {
 	ctx, span := core.TraceMethod(ctx, "LockManagerDefault.AcquireLockWithTimeout")
 	defer span.End()
 
-	if err := lm.validateUserID(userID); err != nil {
-		return nil, err
+	// Return no-op lock for anonymous operations (userID == 0)
+	if userID == 0 {
+		return &noOpLock{}, nil
 	}
 
 	lm.logger.Debug("Acquiring lock with timeout for user",
@@ -149,12 +162,14 @@ func (lm *LockManagerDefault) AcquireLockWithTimeout(ctx context.Context, userID
 // TryAcquireLock attempts to acquire a lock for the specified user ID without blocking.
 // If the lock is immediately available, it returns the Lock handle.
 // Otherwise, it returns ErrLockBusy.
+// For userID 0 (anonymous operations), returns a no-op lock immediately.
 func (lm *LockManagerDefault) TryAcquireLock(ctx context.Context, userID uint) (Lock, error) {
 	ctx, span := core.TraceMethod(ctx, "LockManagerDefault.TryAcquireLock")
 	defer span.End()
 
-	if err := lm.validateUserID(userID); err != nil {
-		return nil, err
+	// Return no-op lock for anonymous operations (userID == 0)
+	if userID == 0 {
+		return &noOpLock{}, nil
 	}
 
 	lm.logger.Debug("Trying to acquire lock for user", zap.Uint("user_id", userID))

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -59,15 +59,19 @@ func TestLockManager_AcquireLock_Success(t *testing.T) {
 	})
 }
 
-// TestLockManager_AcquireLock_InvalidUserID tests that invalid user IDs are rejected.
-func TestLockManager_AcquireLock_InvalidUserID(t *testing.T) {
+// TestLockManager_AcquireLock_AnonymousUserID tests that anonymous user ID (0) returns a no-op lock.
+func TestLockManager_AcquireLock_AnonymousUserID(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		lockManager := NewLockManager(ctx)
 		testCtx := context.Background()
 
-		_, err := lockManager.AcquireLock(testCtx, testInvalidID)
-		assert.Error(t, err, "invalid user ID should return error")
-		assert.Contains(t, err.Error(), "invalid user ID", "error should mention invalid user ID")
+		// Anonymous user ID (0) should return a no-op lock without error
+		lock, err := lockManager.AcquireLock(testCtx, testInvalidID)
+		assert.NoError(t, err, "anonymous user ID should return no-op lock without error")
+		assert.NotNil(t, lock, "lock should not be nil")
+
+		// Release should be safe (no-op)
+		lock.Release()
 	})
 }
 

--- a/internal/service/quota/event_listeners.go
+++ b/internal/service/quota/event_listeners.go
@@ -9,7 +9,6 @@ import (
 	"go.lumeweb.com/portal/core"
 	portalModels "go.lumeweb.com/portal/db/models"
 	portalEvent "go.lumeweb.com/portal/event"
-	quotaLock "go.lumeweb.com/portal-plugin-quota/internal/lock"
 	"go.uber.org/zap"
 )
 
@@ -150,21 +149,17 @@ func (s *QuotaServiceDefault) handleDownloadCompleted(ctx context.Context, uploa
 	// If reservation exists, handle it atomically with recording
 	if reservationUUID != nil {
 		// Acquire user lock to make reservation release + usage recording atomic
-		// Note: For anonymous downloads (effectiveUserID == 0), we skip locking since
-		// there's no user-specific quota to protect
-		var lock quotaLock.Lock
-		var lockErr error
-		if effectiveUserID > 0 {
-			lock, lockErr = s.lockManager.AcquireLock(ctx, effectiveUserID)
-			if lockErr != nil {
-				s.Logger().Error("Failed to acquire user lock for download completed",
-					zap.Uint("effectiveUserID", effectiveUserID),
-					zap.String("reservation_uuid", *reservationUUID),
-					zap.Error(lockErr))
-				return lockErr
-			}
-			defer lock.Release()
+		// The lock manager returns a no-op lock for anonymous operations (effectiveUserID == 0),
+		// which avoids serialized all anonymous operations as a global mutex
+		lock, err := s.lockManager.AcquireLock(ctx, effectiveUserID)
+		if err != nil {
+			s.Logger().Error("Failed to acquire user lock for download completed",
+				zap.Uint("effectiveUserID", effectiveUserID),
+				zap.String("reservation_uuid", *reservationUUID),
+				zap.Error(err))
+			return err
 		}
+		defer lock.Release()
 
 		reservation := s.reservationManager.GetReservation(*reservationUUID)
 		if reservation != nil {

--- a/internal/service/quota/event_listeners.go
+++ b/internal/service/quota/event_listeners.go
@@ -9,6 +9,7 @@ import (
 	"go.lumeweb.com/portal/core"
 	portalModels "go.lumeweb.com/portal/db/models"
 	portalEvent "go.lumeweb.com/portal/event"
+	quotaLock "go.lumeweb.com/portal-plugin-quota/internal/lock"
 	"go.uber.org/zap"
 )
 
@@ -81,8 +82,19 @@ func (s *QuotaServiceDefault) handleUploadCompleted(ctx context.Context, uploadI
 		return nil
 	}
 
-	// If reservation exists, handle it
+	// If reservation exists, handle it atomically with recording
 	if reservationUUID != nil {
+		// Acquire user lock to make reservation release + usage recording atomic
+		lock, err := s.lockManager.AcquireLock(ctx, *userID)
+		if err != nil {
+			s.Logger().Error("Failed to acquire user lock for upload completed",
+				zap.Uint("userID", *userID),
+				zap.String("reservation_uuid", *reservationUUID),
+				zap.Error(err))
+			return err
+		}
+		defer lock.Release()
+
 		reservation := s.reservationManager.GetReservation(*reservationUUID)
 		if reservation != nil {
 			s.Logger().Debug("Releasing reservation for upload",
@@ -93,6 +105,23 @@ func (s *QuotaServiceDefault) handleUploadCompleted(ctx context.Context, uploadI
 
 			// Release reservation (called regardless of success/failure)
 			reservation.Release()
+
+			// If upload was successful, record usage atomically within the lock
+			if successful {
+				s.Logger().Debug("Recording upload usage atomically",
+					zap.Uint("userID", *userID),
+					zap.Uint("uploadID", uploadID),
+					zap.Uint64("bytes", bytes))
+
+				if err := s.RecordUpload(ctx, *userID, uploadID, bytes, ip); err != nil {
+					// Log error but don't fail - the reservation has already been released
+					s.Logger().Error("Failed to record upload usage",
+						zap.Uint("userID", *userID),
+						zap.Uint("uploadID", uploadID),
+						zap.Uint64("bytes", bytes),
+						zap.Error(err))
+				}
+			}
 		}
 		return nil
 	}
@@ -118,8 +147,25 @@ func (s *QuotaServiceDefault) handleDownloadCompleted(ctx context.Context, uploa
 		effectiveUserID = *userID
 	}
 
-	// If reservation exists, handle it
+	// If reservation exists, handle it atomically with recording
 	if reservationUUID != nil {
+		// Acquire user lock to make reservation release + usage recording atomic
+		// Note: For anonymous downloads (effectiveUserID == 0), we skip locking since
+		// there's no user-specific quota to protect
+		var lock quotaLock.Lock
+		var lockErr error
+		if effectiveUserID > 0 {
+			lock, lockErr = s.lockManager.AcquireLock(ctx, effectiveUserID)
+			if lockErr != nil {
+				s.Logger().Error("Failed to acquire user lock for download completed",
+					zap.Uint("effectiveUserID", effectiveUserID),
+					zap.String("reservation_uuid", *reservationUUID),
+					zap.Error(lockErr))
+				return lockErr
+			}
+			defer lock.Release()
+		}
+
 		reservation := s.reservationManager.GetReservation(*reservationUUID)
 		if reservation != nil {
 			s.Logger().Debug("Releasing reservation for download",
@@ -130,17 +176,31 @@ func (s *QuotaServiceDefault) handleDownloadCompleted(ctx context.Context, uploa
 
 			// Release reservation (called regardless of success/failure)
 			reservation.Release()
-		}
 
-		// Track failed downloads in metrics
-		if !successful {
-			DownloadFailed.WithLabelValues().Inc()
-			s.Logger().Debug("Download failed - reservation released",
-				zap.Uint("effectiveUserID", effectiveUserID),
-				zap.String("reservation_uuid", *reservationUUID),
-				zap.Uint64("bytes", bytes))
-		}
+			// If download was successful, record usage atomically within the lock
+			if successful {
+				s.Logger().Debug("Recording download usage atomically",
+					zap.Uint("effectiveUserID", effectiveUserID),
+					zap.Uint("uploadID", uploadID),
+					zap.Uint64("bytes", bytes))
 
+				if err := s.RecordDownload(ctx, effectiveUserID, uploadID, bytes, ip); err != nil {
+					// Log error but don't fail - the reservation has already been released
+					s.Logger().Error("Failed to record download usage",
+						zap.Uint("effectiveUserID", effectiveUserID),
+						zap.Uint("uploadID", uploadID),
+						zap.Uint64("bytes", bytes),
+						zap.Error(err))
+				}
+			} else {
+				// Track failed downloads in metrics
+				DownloadFailed.WithLabelValues().Inc()
+				s.Logger().Debug("Download failed - reservation released",
+					zap.Uint("effectiveUserID", effectiveUserID),
+					zap.String("reservation_uuid", *reservationUUID),
+					zap.Uint64("bytes", bytes))
+			}
+		}
 		return nil
 	}
 

--- a/internal/service/quota/event_listeners_integration_test.go
+++ b/internal/service/quota/event_listeners_integration_test.go
@@ -74,9 +74,8 @@ func TestEventListeners_handleUploadCompleted_WithReservation_Success(t *testing
 		reservation = service.GetReservationManager().GetReservation(reservationUUID)
 		assert.Nil(t, reservation, "reservation should be released after upload completes")
 
-		// The calling code must explicitly call RecordUpload after successful upload
-		err = service.RecordUpload(ctx, userID, uploadID, bytes, ip)
-		require.NoError(t, err)
+		// The event handler now records usage atomically with reservation release
+		// The calling code does NOT need to call RecordUpload again
 
 		// Verify usage detail was created
 		var usageDetails []pluginModels.UserUsageDetail
@@ -263,9 +262,8 @@ func TestEventListeners_handleDownloadCompleted_WithReservation_Success(t *testi
 		reservation = service.GetReservationManager().GetReservation(reservationUUID)
 		assert.Nil(t, reservation, "reservation should be released after download completes")
 
-		// The calling code must explicitly call RecordDownload after successful download
-		err = service.RecordDownload(ctx, userID, uploadID, bytes, ip)
-		require.NoError(t, err)
+		// The event handler now records usage atomically with reservation release
+		// The calling code does NOT need to call RecordDownload again
 
 		// Verify usage detail was created
 		var usageDetails []pluginModels.UserUsageDetail
@@ -602,9 +600,8 @@ func TestQuotaService_ReservationWorkflow_EndToEnd(t *testing.T) {
 		reservation = service.GetReservationManager().GetReservation(reservationUUID)
 		assert.Nil(t, reservation, "reservation should be released after upload completes")
 
-		// The calling code must explicitly call RecordUpload after successful upload
-		err = service.RecordUpload(ctx, userID, uploadID, bytes, ip)
-		require.NoError(t, err)
+		// The event handler now records usage atomically with reservation release
+		// The calling code does NOT need to call RecordUpload again
 
 		// Step 5: Verify usage was recorded
 		var usageDetails []pluginModels.UserUsageDetail


### PR DESCRIPTION
Ensures atomic conversion of pending reservations to actual usage by performing both operations within a single user lock, preventing race conditions during concurrent quota checks.

- `develop` <!-- branch-stack -->
  - **refactor(quota): make reservation release and usage recording atomic** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR refactors the quota event handlers to make reservation release and usage recording atomic operations, ensuring data consistency and simplifying the calling workflow.

**Changes:**

- **Atomic reservation release and usage recording**: Modified `handleUploadCompleted` and `handleDownloadCompleted` to acquire user-specific locks before releasing reservations. Usage recording (`RecordUpload` and `RecordDownload`) now executes atomically within the same lock scope immediately after reservation release.

- **Simplified caller workflow**: The event handlers now automatically record usage for successful transfers, eliminating the need for calling code to explicitly invoke `RecordUpload` or `RecordDownload` after successful uploads/downloads.

- **Anonymous download handling**: For downloads, the lock is only acquired when `effectiveUserID > 0`. Anonymous downloads (where `effectiveUserID == 0`) skip locking since there is no user-specific quota to protect.

- **Updated test expectations**: Integration tests updated to reflect that usage recording is now handled internally by the event handlers rather than requiring separate calls from the client code.

**Functional Impact:**

- Prevents race conditions between reservation release and usage recording that could lead to quota calculation inconsistencies
- Ensures that reserved quota is properly converted to actual usage in a single atomic operation
- Reduces complexity for API consumers by handling the complete reservation-to-usage workflow within the event handlers

<!-- kody-pr-summary:end -->
