### PR TITLE
fix: correct window_usage_before logging to prevent integer underflow

### DIFF
--- a/internal/service/policies/hard_limits.go
+++ b/internal/service/policies/hard_limits.go
@@ -18,6 +18,26 @@ type HardLimitsPolicyEnforcer struct {
 	limitResolver pluginCore.LimitResolver
 }
 
+// logActiveReservations logs active reservation information for debugging
+func (h *HardLimitsPolicyEnforcer) logActiveReservations(ctx context.Context, userID uint, usageType models.UsageType, currentUsage uint64, usageTypeName string) {
+	pendingBytes := h.reservationManager.SumPendingBytesForUser(ctx, userID, usageType)
+	if pendingBytes > 0 {
+		concurrentCount := h.reservationManager.CountPendingReservationsForUser(ctx, userID, usageType)
+		windowUsageBefore := currentUsage
+		if currentUsage >= uint64(pendingBytes) {
+			windowUsageBefore = currentUsage - uint64(pendingBytes)
+		}
+		h.logger.Debug("Active reservations for user",
+			zap.Uint("user_id", userID),
+			zap.String("usage_type", usageTypeName),
+			zap.Int64("pending_bytes", pendingBytes),
+			zap.Int("concurrent_count", concurrentCount),
+			zap.Uint64("window_usage_before", windowUsageBefore),
+			zap.Uint64("window_usage_after", currentUsage),
+		)
+	}
+}
+
 // NewHardLimitsPolicyEnforcer creates a new hard limits policy enforcer
 func NewHardLimitsPolicyEnforcer(ctx core.Context, quotaService pluginCore.QuotaService) *HardLimitsPolicyEnforcer {
 	return &HardLimitsPolicyEnforcer{
@@ -66,24 +86,12 @@ func (h *HardLimitsPolicyEnforcer) CheckUploadQuota(ctx context.Context, config 
 				return pluginCore.QuotaCheckResult{}, fmt.Errorf("failed to get usage for upload window: %w", err)
 			}
 
-			// Query pending reservations
+			// Include pending reservations and log for debugging
 			pendingBytes := h.reservationManager.SumPendingBytesForUser(ctx, config.UserID, models.UsageTypeUpload)
 			if pendingBytes < 0 {
 				return pluginCore.QuotaCheckResult{}, fmt.Errorf("invalid pending bytes: %d", pendingBytes)
 			}
-			
-			// Log active reservation sum for debugging
-			if pendingBytes > 0 {
-				concurrentCount := h.reservationManager.CountPendingReservationsForUser(ctx, config.UserID, models.UsageTypeUpload)
-				h.logger.Debug("Active reservations for user",
-					zap.Uint("user_id", config.UserID),
-					zap.String("usage_type", "upload"),
-					zap.Int64("pending_bytes", pendingBytes),
-					zap.Int("concurrent_count", concurrentCount),
-					zap.Uint64("window_usage_before", currentUsage-uint64(pendingBytes)),
-					zap.Uint64("window_usage_after", currentUsage),
-				)
-			}
+			h.logActiveReservations(ctx, config.UserID, models.UsageTypeUpload, currentUsage, "upload")
 			currentUsage += uint64(pendingBytes)
 
 			limitValue := windowLimits.Bytes
@@ -146,24 +154,12 @@ func (h *HardLimitsPolicyEnforcer) CheckDownloadQuota(ctx context.Context, confi
 				return pluginCore.QuotaCheckResult{}, fmt.Errorf("failed to get usage for download window: %w", err)
 			}
 
-			// Query pending reservations
+			// Include pending reservations and log for debugging
 			pendingBytes := h.reservationManager.SumPendingBytesForUser(ctx, config.UserID, models.UsageTypeDownload)
 			if pendingBytes < 0 {
 				return pluginCore.QuotaCheckResult{}, fmt.Errorf("invalid pending bytes: %d", pendingBytes)
 			}
-			
-			// Log active reservation sum for debugging
-			if pendingBytes > 0 {
-				concurrentCount := h.reservationManager.CountPendingReservationsForUser(ctx, config.UserID, models.UsageTypeDownload)
-				h.logger.Debug("Active reservations for user",
-					zap.Uint("user_id", config.UserID),
-					zap.String("usage_type", "download"),
-					zap.Int64("pending_bytes", pendingBytes),
-					zap.Int("concurrent_count", concurrentCount),
-					zap.Uint64("window_usage_before", currentUsage-uint64(pendingBytes)),
-					zap.Uint64("window_usage_after", currentUsage),
-				)
-			}
+			h.logActiveReservations(ctx, config.UserID, models.UsageTypeDownload, currentUsage, "download")
 			currentUsage += uint64(pendingBytes)
 			limitValue := windowLimits.Bytes
 
@@ -225,24 +221,12 @@ func (h *HardLimitsPolicyEnforcer) CheckStorageQuota(ctx context.Context, config
 				return pluginCore.QuotaCheckResult{}, fmt.Errorf("failed to get usage for storage window: %w", err)
 			}
 
-			// Query pending reservations
+			// Include pending reservations and log for debugging
 			pendingBytes := h.reservationManager.SumPendingBytesForUser(ctx, config.UserID, models.UsageTypeStorageAdd)
 			if pendingBytes < 0 {
 				return pluginCore.QuotaCheckResult{}, fmt.Errorf("invalid pending bytes: %d", pendingBytes)
 			}
-			
-			// Log active reservation sum for debugging
-			if pendingBytes > 0 {
-				concurrentCount := h.reservationManager.CountPendingReservationsForUser(ctx, config.UserID, models.UsageTypeStorageAdd)
-				h.logger.Debug("Active reservations for user",
-					zap.Uint("user_id", config.UserID),
-					zap.String("usage_type", "storage"),
-					zap.Int64("pending_bytes", pendingBytes),
-					zap.Int("concurrent_count", concurrentCount),
-					zap.Uint64("window_usage_before", currentUsage-uint64(pendingBytes)),
-					zap.Uint64("window_usage_after", currentUsage),
-				)
-			}
+			h.logActiveReservations(ctx, config.UserID, models.UsageTypeStorageAdd, currentUsage, "storage")
 			currentUsage += uint64(pendingBytes)
 
 			limitValue := windowLimits.Bytes


### PR DESCRIPTION
Resolves unrealistic window\_usage\_before values (e.g., 18446744073709551324) in debug logs when pending reservations exceed current window usage. Logs now safely handle this case without integer underflow.

- `develop` <!-- branch-stack -->
  - **fix: correct window\_usage\_before logging to prevent integer underflow** :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request fixes an integer underflow issue in debug logging for quota usage tracking and refactors duplicate logging code into a reusable method.

**Key Changes:**

1. **Fixed Integer Underflow in Usage Logging**: Corrected the calculation of `window_usage_before` in debug logs to prevent integer underflow when pending reservation bytes exceed the current usage amount. The fix adds a bounds check to ensure subtraction only occurs when `currentUsage >= pendingBytes`, otherwise defaulting to the current usage value.

2. **Refactored Logging Logic**: Extracted the active reservation logging code from `CheckUploadQuota`, `CheckDownloadQuota`, and `CheckStorageQuota` into a new dedicated method `logActiveReservations`. This eliminates code duplication while maintaining the same debug output format.

**Functional Impact:**

- Ensures accurate debug logging of quota usage statistics before and after pending reservations are applied
- Prevents misleading log entries that would display incorrect (wrapped) values for `window_usage_before` when users have pending reservations larger than their current window usage
- Improves maintainability of the quota enforcement logging across upload, download, and storage quota checks
<!-- kody-pr-summary:end -->