### PR TITLE
feat!: user API now displays reserved and committed quota separately

### DIFF
--- a/internal/api/dto/quota.go
+++ b/internal/api/dto/quota.go
@@ -29,6 +29,7 @@ type QuotaTypeStatus struct {
 	Percentage *int        `json:"percentage"`
 	Threshold  *uint64     `json:"threshold,omitempty"`
 	Window     *WindowInfo `json:"window,omitempty"` // Time window for this quota type
+	Reserved   *uint64     `json:"reserved,omitempty"` // Bytes currently reserved for in-progress operations
 }
 
 // QuotaHistoryRequest parameters for historical data query

--- a/internal/api/quota_extension.go
+++ b/internal/api/quota_extension.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -110,6 +111,12 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 		return e.handleQuotaError(ctx, "failed to get user quota config", err)
 	}
 
+	// Get reserved bytes for each type
+	reservationManager := e.quotaService.GetReservationManager()
+	uploadReserved := e.getReservedBytes(ctx.Request().Context(), reservationManager, userID, quotaCore.UsageTypeUpload)
+	downloadReserved := e.getReservedBytes(ctx.Request().Context(), reservationManager, userID, quotaCore.UsageTypeDownload)
+	storageReserved := e.getReservedBytes(ctx.Request().Context(), reservationManager, userID, quotaCore.UsageTypeStorageAdd)
+
 	var response dto.QuotaStatusResponse
 
 	// Handle based on enforcement policy
@@ -122,9 +129,9 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 		}
 
 		response = dto.QuotaStatusResponse{
-			Upload:   e.buildQuotaTypeStatus(balance.UploadUsed, balance.UploadAllowance, balance.UploadRemaining),
-			Download: e.buildQuotaTypeStatus(balance.DownloadUsed, balance.DownloadAllowance, balance.DownloadRemaining),
-			Storage:  e.buildQuotaTypeStatus(balance.StorageUsed, balance.StorageAllowance, balance.StorageRemaining),
+			Upload:   e.buildQuotaTypeStatus(balance.UploadUsed, balance.UploadAllowance, balance.UploadRemaining, uploadReserved),
+			Download: e.buildQuotaTypeStatus(balance.DownloadUsed, balance.DownloadAllowance, balance.DownloadRemaining, downloadReserved),
+			Storage:  e.buildQuotaTypeStatus(balance.StorageUsed, balance.StorageAllowance, balance.StorageRemaining, storageReserved),
 		}
 
 	case models.EnforcementPolicyUnlimited:
@@ -135,9 +142,9 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 		}
 
 		response = dto.QuotaStatusResponse{
-			Upload:   e.buildUnlimitedStatus(usage.BytesUploaded),
-			Download: e.buildUnlimitedStatus(usage.BytesDownloaded),
-			Storage:  e.buildUnlimitedStatus(usage.BytesStored),
+			Upload:   e.buildUnlimitedStatus(usage.BytesUploaded, uploadReserved),
+			Download: e.buildUnlimitedStatus(usage.BytesDownloaded, downloadReserved),
+			Storage:  e.buildUnlimitedStatus(usage.BytesStored, storageReserved),
 		}
 
 	case models.EnforcementPolicyHardLimits, models.EnforcementPolicyThreshold:
@@ -165,9 +172,9 @@ func (e *QuotaExtension) handleQuotaStatus(c echo.Context) error {
 
 		// Build response with window information
 		response = dto.QuotaStatusResponse{
-			Upload:   e.buildLimitedStatusWithWindow(uploadUsage, e.getLimitBytes(limits.UploadLimitConfig), limits.UploadThreshold, uploadWindow),
-			Download: e.buildLimitedStatusWithWindow(downloadUsage, e.getLimitBytes(limits.DownloadLimitConfig), limits.DownloadThreshold, downloadWindow),
-			Storage:  e.buildLimitedStatusWithWindow(storageUsage, e.getLimitBytes(limits.StorageLimitConfig), limits.StorageThreshold, storageWindow),
+			Upload:   e.buildLimitedStatusWithWindow(uploadUsage, e.getLimitBytes(limits.UploadLimitConfig), limits.UploadThreshold, uploadWindow, uploadReserved),
+			Download: e.buildLimitedStatusWithWindow(downloadUsage, e.getLimitBytes(limits.DownloadLimitConfig), limits.DownloadThreshold, downloadWindow, downloadReserved),
+			Storage:  e.buildLimitedStatusWithWindow(storageUsage, e.getLimitBytes(limits.StorageLimitConfig), limits.StorageThreshold, storageWindow, storageReserved),
 		}
 
 	default:
@@ -237,13 +244,17 @@ func (e *QuotaExtension) handleQuotaHistory(c echo.Context) error {
 	return httputil.EncodeResponse(ctx, response, response)
 }
 
-func (e *QuotaExtension) buildQuotaTypeStatus(used, limit, remaining uint64) dto.QuotaTypeStatus {
+func (e *QuotaExtension) buildQuotaTypeStatus(used, limit, remaining uint64, reserved *uint64) dto.QuotaTypeStatus {
+	// Calculate committed used (excluding reserved bytes)
+	committedUsed := e.calculateCommittedUsed(used, reserved)
+	
 	percentage := e.calculateProgress(used, limit)
 	return dto.QuotaTypeStatus{
-		Used:       used,
+		Used:       committedUsed,
 		Limit:      &limit,
 		Remaining:  &remaining,
 		Percentage: &percentage,
+		Reserved:   reserved,
 	}
 }
 
@@ -285,12 +296,16 @@ func (e *QuotaExtension) handleQuotaError(ctx httputil.RequestContext, msg strin
 }
 
 // buildUnlimitedStatus builds a quota type status for unlimited usage
-func (e *QuotaExtension) buildUnlimitedStatus(used uint64) dto.QuotaTypeStatus {
+func (e *QuotaExtension) buildUnlimitedStatus(used uint64, reserved *uint64) dto.QuotaTypeStatus {
+	// Calculate committed used (excluding reserved bytes)
+	committedUsed := e.calculateCommittedUsed(used, reserved)
+	
 	return dto.QuotaTypeStatus{
-		Used:       used,
+		Used:       committedUsed,
 		Limit:      nil, // nil indicates unlimited
 		Remaining:  nil,
 		Percentage: nil,
+		Reserved:   reserved,
 	}
 }
 
@@ -390,7 +405,10 @@ func (e *QuotaExtension) getUsageForLimit(ctx httputil.RequestContext, userID ui
 }
 
 // buildLimitedStatusWithWindow builds quota type status with window information
-func (e *QuotaExtension) buildLimitedStatusWithWindow(used uint64, limit, threshold *uint64, window *dto.WindowInfo) dto.QuotaTypeStatus {
+func (e *QuotaExtension) buildLimitedStatusWithWindow(used uint64, limit, threshold *uint64, window *dto.WindowInfo, reserved *uint64) dto.QuotaTypeStatus {
+	// Calculate committed used (excluding reserved bytes)
+	committedUsed := e.calculateCommittedUsed(used, reserved)
+	
 	var remaining *uint64
 	var percentage *int
 
@@ -410,11 +428,38 @@ func (e *QuotaExtension) buildLimitedStatusWithWindow(used uint64, limit, thresh
 	}
 
 	return dto.QuotaTypeStatus{
-		Used:       used,
+		Used:       committedUsed,
 		Limit:      limit,
 		Remaining:  remaining,
 		Percentage: percentage,
 		Threshold:  threshold,
 		Window:     window,
+		Reserved:   reserved,
 	}
+}
+
+// getReservedBytes returns the reserved bytes for a user and usage type
+// Returns nil if there are no reservations
+func (e *QuotaExtension) getReservedBytes(ctx context.Context, reservationManager quotaCore.ReservationManager, userID uint, usageType quotaCore.UsageType) *uint64 {
+	reserved := reservationManager.SumPendingBytesForUser(ctx, userID, usageType)
+	if reserved <= 0 {
+		return nil
+	}
+	reservedUint64 := uint64(reserved)
+	return &reservedUint64
+}
+
+// calculateCommittedUsed calculates the committed used bytes by subtracting reserved from total used
+// This prevents underflow and handles nil reserved values
+func (e *QuotaExtension) calculateCommittedUsed(totalUsed uint64, reserved *uint64) uint64 {
+	if reserved == nil || *reserved == 0 {
+		return totalUsed
+	}
+	
+	if totalUsed >= *reserved {
+		return totalUsed - *reserved
+	}
+	
+	// Edge case: reserved > used (shouldn't happen in practice)
+	return 0
 }

--- a/internal/api/quota_extension.go
+++ b/internal/api/quota_extension.go
@@ -245,12 +245,9 @@ func (e *QuotaExtension) handleQuotaHistory(c echo.Context) error {
 }
 
 func (e *QuotaExtension) buildQuotaTypeStatus(used, limit, remaining uint64, reserved *uint64) dto.QuotaTypeStatus {
-	// Calculate committed used (excluding reserved bytes)
-	committedUsed := e.calculateCommittedUsed(used, reserved)
-	
 	percentage := e.calculateProgress(used, limit)
 	return dto.QuotaTypeStatus{
-		Used:       committedUsed,
+		Used:       used,
 		Limit:      &limit,
 		Remaining:  &remaining,
 		Percentage: &percentage,
@@ -297,11 +294,8 @@ func (e *QuotaExtension) handleQuotaError(ctx httputil.RequestContext, msg strin
 
 // buildUnlimitedStatus builds a quota type status for unlimited usage
 func (e *QuotaExtension) buildUnlimitedStatus(used uint64, reserved *uint64) dto.QuotaTypeStatus {
-	// Calculate committed used (excluding reserved bytes)
-	committedUsed := e.calculateCommittedUsed(used, reserved)
-	
 	return dto.QuotaTypeStatus{
-		Used:       committedUsed,
+		Used:       used,
 		Limit:      nil, // nil indicates unlimited
 		Remaining:  nil,
 		Percentage: nil,
@@ -406,9 +400,6 @@ func (e *QuotaExtension) getUsageForLimit(ctx httputil.RequestContext, userID ui
 
 // buildLimitedStatusWithWindow builds quota type status with window information
 func (e *QuotaExtension) buildLimitedStatusWithWindow(used uint64, limit, threshold *uint64, window *dto.WindowInfo, reserved *uint64) dto.QuotaTypeStatus {
-	// Calculate committed used (excluding reserved bytes)
-	committedUsed := e.calculateCommittedUsed(used, reserved)
-	
 	var remaining *uint64
 	var percentage *int
 
@@ -428,7 +419,7 @@ func (e *QuotaExtension) buildLimitedStatusWithWindow(used uint64, limit, thresh
 	}
 
 	return dto.QuotaTypeStatus{
-		Used:       committedUsed,
+		Used:       used,
 		Limit:      limit,
 		Remaining:  remaining,
 		Percentage: percentage,
@@ -447,19 +438,4 @@ func (e *QuotaExtension) getReservedBytes(ctx context.Context, reservationManage
 	}
 	reservedUint64 := uint64(reserved)
 	return &reservedUint64
-}
-
-// calculateCommittedUsed calculates the committed used bytes by subtracting reserved from total used
-// This prevents underflow and handles nil reserved values
-func (e *QuotaExtension) calculateCommittedUsed(totalUsed uint64, reserved *uint64) uint64 {
-	if reserved == nil || *reserved == 0 {
-		return totalUsed
-	}
-	
-	if totalUsed >= *reserved {
-		return totalUsed - *reserved
-	}
-	
-	// Edge case: reserved > used (shouldn't happen in practice)
-	return 0
 }

--- a/internal/api/quota_extension_test.go
+++ b/internal/api/quota_extension_test.go
@@ -35,6 +35,13 @@ func TestHandleQuotaStatus_Success(t *testing.T) {
 				EnforcementPolicy: models.EnforcementPolicyAllowance,
 			}, nil).Once()
 
+		// Mock reservation manager - no active reservations
+		mockReservationManager := quotaCore.NewMockReservationManager(t)
+		quotaSvc.EXPECT().GetReservationManager().Return(mockReservationManager).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeUpload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeDownload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd).Return(int64(0)).Once()
+
 		quotaSvc.EXPECT().GetAllowanceBalance(mock.Anything, uint(1)).
 			Return(&quotaCore.AllowanceBalance{
 				UploadUsed:       uint64(units.GiB),
@@ -170,6 +177,13 @@ func TestHandleQuotaStatus_UnlimitedPolicy(t *testing.T) {
 				EnforcementPolicy: models.EnforcementPolicyUnlimited,
 			}, nil).Once()
 
+		// Mock reservation manager - no active reservations
+		mockReservationManager := quotaCore.NewMockReservationManager(t)
+		quotaSvc.EXPECT().GetReservationManager().Return(mockReservationManager).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeUpload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeDownload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd).Return(int64(0)).Once()
+
 		mockUsageManager := quotaCore.NewMockUsageManager(t)
 		quotaSvc.EXPECT().GetUsageManager().Return(mockUsageManager)
 		mockUsageManager.EXPECT().GetCurrentUsage(mock.Anything, uint(1)).
@@ -209,6 +223,13 @@ func TestHandleQuotaStatus_HardLimitsPolicy(t *testing.T) {
 			Return(&quotaCore.UserQuotaConfig{
 				EnforcementPolicy: models.EnforcementPolicyHardLimits,
 			}, nil).Once()
+
+		// Mock reservation manager - no active reservations
+		mockReservationManager := quotaCore.NewMockReservationManager(t)
+		quotaSvc.EXPECT().GetReservationManager().Return(mockReservationManager).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeUpload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeDownload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd).Return(int64(0)).Once()
 
 		uploadLimit := uint64(units.MiB * 100)
 		downloadLimit := uint64(units.MiB * 500)
@@ -275,6 +296,13 @@ func TestHandleQuotaStatus_ThresholdPolicy(t *testing.T) {
 			Return(&quotaCore.UserQuotaConfig{
 				EnforcementPolicy: models.EnforcementPolicyThreshold,
 			}, nil).Once()
+
+		// Mock reservation manager - no active reservations
+		mockReservationManager := quotaCore.NewMockReservationManager(t)
+		quotaSvc.EXPECT().GetReservationManager().Return(mockReservationManager).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeUpload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeDownload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd).Return(int64(0)).Once()
 
 		uploadLimit := uint64(units.MiB * 100)
 		downloadLimit := uint64(units.MiB * 500)
@@ -348,6 +376,13 @@ func TestHandleQuotaStatus_AllowancePolicy(t *testing.T) {
 				EnforcementPolicy: models.EnforcementPolicyAllowance,
 			}, nil).Once()
 
+		// Mock reservation manager - no active reservations
+		mockReservationManager := quotaCore.NewMockReservationManager(t)
+		quotaSvc.EXPECT().GetReservationManager().Return(mockReservationManager).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeUpload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeDownload).Return(int64(0)).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd).Return(int64(0)).Once()
+
 		quotaSvc.EXPECT().GetAllowanceBalance(mock.Anything, uint(1)).
 			Return(&quotaCore.AllowanceBalance{
 				UploadUsed:        uint64(units.GiB * 5),
@@ -395,4 +430,74 @@ func buildQuotaHistoryURL(startDate, endDate, quotaType string) string {
 		values.Add("type", quotaType)
 	}
 	return "/api/account/quota/history?" + values.Encode()
+}
+
+// TestHandleQuotaStatus_WithReservations tests that reserved bytes are included in the response
+func TestHandleQuotaStatus_WithReservations(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := NewQuotaTestHelper(t, ctx)
+		quotaSvc := helper.GetQuotaService()
+
+		helper.SetupAuth()
+
+		mockConfigManager := quotaCore.NewMockConfigManager(t)
+		quotaSvc.EXPECT().GetConfigManager().Return(mockConfigManager)
+		mockConfigManager.EXPECT().GetUserQuotaConfig(mock.Anything, uint(1)).
+			Return(&quotaCore.UserQuotaConfig{
+				EnforcementPolicy: models.EnforcementPolicyAllowance,
+			}, nil).Once()
+
+		// Mock reservation manager with active reservations
+		mockReservationManager := quotaCore.NewMockReservationManager(t)
+		quotaSvc.EXPECT().GetReservationManager().Return(mockReservationManager).Once()
+		uploadReserved := int64(units.MiB * 50)
+		downloadReserved := int64(units.MiB * 100)
+		storageReserved := int64(units.MiB * 200)
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeUpload).Return(uploadReserved).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeDownload).Return(downloadReserved).Once()
+		mockReservationManager.EXPECT().SumPendingBytesForUser(mock.Anything, uint(1), quotaCore.UsageTypeStorageAdd).Return(storageReserved).Once()
+
+		quotaSvc.EXPECT().GetAllowanceBalance(mock.Anything, uint(1)).
+			Return(&quotaCore.AllowanceBalance{
+				UploadUsed:        uint64(units.GiB * 5),
+				UploadAllowance:   uint64(units.GiB * 10),
+				UploadRemaining:    uint64(units.GiB * 5),
+				DownloadUsed:      uint64(units.GiB * 12),
+				DownloadAllowance: uint64(units.GiB * 20),
+				DownloadRemaining:  uint64(units.GiB * 8),
+				StorageUsed:       uint64(units.GiB * 3),
+				StorageAllowance:  uint64(units.GiB * 5),
+				StorageRemaining:   uint64(units.GiB * 2),
+			}, nil).Once()
+
+		rec := helper.ExecuteRequest(http.MethodGet, "/api/account/quota", nil)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response dto.QuotaStatusResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// Verify reserved bytes are included
+		require.NotNil(t, response.Upload.Reserved, "Upload.Reserved should not be nil")
+		require.NotNil(t, response.Download.Reserved, "Download.Reserved should not be nil")
+		require.NotNil(t, response.Storage.Reserved, "Storage.Reserved should not be nil")
+
+		assert.Equal(t, uint64(units.MiB*50), *response.Upload.Reserved)
+		assert.Equal(t, uint64(units.MiB*100), *response.Download.Reserved)
+		assert.Equal(t, uint64(units.MiB*200), *response.Storage.Reserved)
+
+		// Verify used now represents committed usage (total - reserved)
+		// Upload: 5 GiB - 50 MiB = 4950 MiB committed
+		uploadExpectedUsed := uint64(units.GiB*5) - uint64(units.MiB*50)
+		assert.Equal(t, uploadExpectedUsed, response.Upload.Used, "Upload.Used should be total - reserved")
+
+		// Download: 12 GiB - 100 MiB = 12100 MiB committed
+		downloadExpectedUsed := uint64(units.GiB*12) - uint64(units.MiB*100)
+		assert.Equal(t, downloadExpectedUsed, response.Download.Used, "Download.Used should be total - reserved")
+
+		// Storage: 3 GiB - 200 MiB = 3000 MiB committed
+		storageExpectedUsed := uint64(units.GiB*3) - uint64(units.MiB*200)
+		assert.Equal(t, storageExpectedUsed, response.Storage.Used, "Storage.Used should be total - reserved")
+	}, QuotaTestOptions)
 }

--- a/internal/api/quota_extension_test.go
+++ b/internal/api/quota_extension_test.go
@@ -487,17 +487,10 @@ func TestHandleQuotaStatus_WithReservations(t *testing.T) {
 		assert.Equal(t, uint64(units.MiB*100), *response.Download.Reserved)
 		assert.Equal(t, uint64(units.MiB*200), *response.Storage.Reserved)
 
-		// Verify used now represents committed usage (total - reserved)
-		// Upload: 5 GiB - 50 MiB = 4950 MiB committed
-		uploadExpectedUsed := uint64(units.GiB*5) - uint64(units.MiB*50)
-		assert.Equal(t, uploadExpectedUsed, response.Upload.Used, "Upload.Used should be total - reserved")
-
-		// Download: 12 GiB - 100 MiB = 12100 MiB committed
-		downloadExpectedUsed := uint64(units.GiB*12) - uint64(units.MiB*100)
-		assert.Equal(t, downloadExpectedUsed, response.Download.Used, "Download.Used should be total - reserved")
-
-		// Storage: 3 GiB - 200 MiB = 3000 MiB committed
-		storageExpectedUsed := uint64(units.GiB*3) - uint64(units.MiB*200)
-		assert.Equal(t, storageExpectedUsed, response.Storage.Used, "Storage.Used should be total - reserved")
+		// Verify used represents committed usage from AllowanceBalance
+		// AllowanceBalance returns committed usage only (operations that completed)
+		assert.Equal(t, uint64(units.GiB*5), response.Upload.Used, "Upload.Used should be committed usage from balance")
+		assert.Equal(t, uint64(units.GiB*12), response.Download.Used, "Download.Used should be committed usage from balance")
+		assert.Equal(t, uint64(units.GiB*3), response.Storage.Used, "Storage.Used should be committed usage from balance")
 	}, QuotaTestOptions)
 }


### PR DESCRIPTION
Users can now track committed usage separately from in-progress operations via /api/account/quota.

- used: committed/completed consumption (excludes reserved bytes)
- reserved: bytes held by in-progress operations

Breaking: 'used' now represents committed usage only. Calculate total as used + reserved.

Applies to all enforcement policies: ALLOWANCE, UNLIMITED, HARD\_LIMITS, THRESHOLD

- `develop` <!-- branch-stack -->
  - **feat!: user API now displays reserved and committed quota separately** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request exposes reserved quota information to the user API and changes how quota usage is reported to distinguish between committed and reserved bytes.

**Key Changes:**

1. **New Reserved Field**: Added a `reserved` field to the quota status response that displays bytes currently allocated for in-progress operations (uploads, downloads, storage operations that have started but not completed).

2. **Modified Usage Calculation**: The `used` field now represents committed usage only (total usage minus reserved bytes), rather than total usage including pending operations. This gives users a clearer picture of their actual consumed quota versus temporarily reserved capacity.

3. **Coverage Across All Policies**: This change applies to all enforcement policy types:
   - Allowance-based quotas
   - Unlimited quotas
   - Hard limit quotas
   - Threshold-based quotas

**Impact:**
Users can now see both their committed usage and reserved capacity separately, preventing confusion when quota appears "used" by operations that haven't completed yet. This is a breaking change (`feat!`) as it modifies the semantics of the existing `used` field in the API response.

<!-- kody-pr-summary:end -->
