### PR TITLE
feat: add quota plan changed event emission

### DIFF
--- a/internal/event/quota_events.go
+++ b/internal/event/quota_events.go
@@ -1,0 +1,34 @@
+package event
+
+import (
+	"context"
+	"time"
+
+	"go.lumeweb.com/portal/core"
+)
+
+const EventQuotaPlanChanged = "quota.plan.changed"
+
+type QuotaPlanChangedEvent struct {
+	Ctx       context.Context `json:"-"`
+	UserID    uint            `json:"user_id"`
+	OldPlanID *uint64         `json:"old_plan_id,omitempty"`
+	NewPlanID *uint64         `json:"new_plan_id,omitempty"`
+	ChangedAt time.Time       `json:"changed_at"`
+}
+
+func NewQuotaPlanChangedEvent(ctx context.Context, userID uint, oldPlanID, newPlanID *uint64) *QuotaPlanChangedEvent {
+	return &QuotaPlanChangedEvent{
+		Ctx:       ctx,
+		UserID:    userID,
+		OldPlanID: oldPlanID,
+		NewPlanID: newPlanID,
+		ChangedAt: time.Now(),
+	}
+}
+
+func OnQuotaPlanChanged(ctx core.Context, handler func(context.Context, QuotaPlanChangedEvent) error, priority ...int) {
+	core.Listen[QuotaPlanChangedEvent](ctx, EventQuotaPlanChanged, func(e *core.CoreEvent[QuotaPlanChangedEvent]) error {
+		return handler(e.Data.Ctx, e.Data)
+	}, priority...)
+}

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -12,6 +12,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal-plugin-quota/internal/config"
 	"go.lumeweb.com/portal-plugin-quota/internal/db/models"
+	quotaEvent "go.lumeweb.com/portal-plugin-quota/internal/event"
 	quotaLock "go.lumeweb.com/portal-plugin-quota/internal/lock"
 	quotaReservation "go.lumeweb.com/portal-plugin-quota/internal/reservation"
 	"go.lumeweb.com/portal-plugin-quota/internal/service/managers"
@@ -757,6 +758,7 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 	}
 
 	var updatedConfig models.UserQuotaConfig
+	var oldPlanID *uint64
 
 	// Ensure the user has a quota config first, then apply updates
 	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
@@ -769,6 +771,8 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 			return result
 		}
 
+		oldPlanID = config.QuotaPlanID
+
 		// Apply the updates to the found/created config
 		if result = tx.Model(&config).Updates(updates); result.Error != nil {
 			return result
@@ -778,6 +782,17 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 		return tx.Where("user_id = ?", userID).First(&updatedConfig)
 	}); err != nil {
 		return nil, fmt.Errorf("failed to update user quota config: %w", err)
+	}
+
+	if update.QuotaPlanID != nil {
+		event := quotaEvent.NewQuotaPlanChangedEvent(ctx, userID, oldPlanID, update.QuotaPlanID)
+		if err := core.Fire[quotaEvent.QuotaPlanChangedEvent](
+			s.Context(),
+			quotaEvent.EventQuotaPlanChanged,
+			event,
+		); err != nil {
+			s.Logger().Error("failed to emit quota plan changed event", zap.Error(err))
+		}
 	}
 
 	return &updatedConfig, nil
@@ -796,11 +811,26 @@ func (s *QuotaServiceDefault) ResetUserQuotaPlan(ctx context.Context, userID uin
 		return fmt.Errorf("invalid user ID")
 	}
 
+	var oldPlanID *uint64
+
 	// Update the quota config to remove the plan ID
 	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		var existingConfig models.UserQuotaConfig
+		if result := tx.Where("user_id = ?", userID).First(&existingConfig); result.Error == nil {
+			oldPlanID = existingConfig.QuotaPlanID
+		}
 		return tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", nil)
 	}); err != nil {
 		return fmt.Errorf("failed to reset user quota plan: %w", err)
+	}
+
+	event := quotaEvent.NewQuotaPlanChangedEvent(ctx, userID, oldPlanID, nil)
+	if err := core.Fire[quotaEvent.QuotaPlanChangedEvent](
+		s.Context(),
+		quotaEvent.EventQuotaPlanChanged,
+		event,
+	); err != nil {
+		s.Logger().Error("failed to emit quota plan changed event", zap.Error(err))
 	}
 
 	return nil


### PR DESCRIPTION
Emit a quota.plan.changed event when a user's quota plan is changed, enabling other plugins to react to plan assignments, updates, and removals.

- Add internal/event/quota\_events.go with QuotaPlanChangedEvent, factory, and OnQuotaPlanChanged listener helper
- Emit event from UpdateUserQuotaConfig when QuotaPlanID changes
- Emit event from ResetUserQuotaPlan after plan removal

* `develop` <!-- branch-stack -->
  - **feat: add quota plan changed event emission** :point\_left:

***

<!-- kody-pr-summary:start -->

Add `quota.plan.changed` event emission when a user's quota plan is modified or reset

This PR introduces a new `QuotaPlanChangedEvent` that is emitted whenever a user's quota plan changes. The event includes the user ID, the old plan ID, the new plan ID, and the timestamp of the change. Events are fired in two scenarios:

- **UpdateUserQuotaConfig**: When a user's quota plan is updated to a new plan, the event is emitted with both the old and new plan IDs.
- **ResetUserQuotaPlan**: When a user's quota plan is reset (removed), the event is emitted with the old plan ID and `nil` as the new plan ID.

A helper function `OnQuotaPlanChanged` is also provided for other components to easily register listeners for this event.

<!-- kody-pr-summary:end -->
