### PR TITLE
refactor: move QuotaPlanChangedEvent to core package for cross-plugin access

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -1,10 +1,10 @@
-package event
+package core
 
 import (
 	"context"
 	"time"
 
-	"go.lumeweb.com/portal/core"
+	portalCore "go.lumeweb.com/portal/core"
 )
 
 const EventQuotaPlanChanged = "quota.plan.changed"
@@ -27,8 +27,8 @@ func NewQuotaPlanChangedEvent(ctx context.Context, userID uint, oldPlanID, newPl
 	}
 }
 
-func OnQuotaPlanChanged(ctx core.Context, handler func(context.Context, QuotaPlanChangedEvent) error, priority ...int) {
-	core.Listen[QuotaPlanChangedEvent](ctx, EventQuotaPlanChanged, func(e *core.CoreEvent[QuotaPlanChangedEvent]) error {
+func OnQuotaPlanChanged(ctx portalCore.Context, handler func(context.Context, QuotaPlanChangedEvent) error, priority ...int) {
+	portalCore.Listen[QuotaPlanChangedEvent](ctx, EventQuotaPlanChanged, func(e *portalCore.CoreEvent[QuotaPlanChangedEvent]) error {
 		return handler(e.Data.Ctx, e.Data)
 	}, priority...)
 }

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -12,7 +12,6 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal-plugin-quota/internal/config"
 	"go.lumeweb.com/portal-plugin-quota/internal/db/models"
-	quotaEvent "go.lumeweb.com/portal-plugin-quota/internal/event"
 	quotaLock "go.lumeweb.com/portal-plugin-quota/internal/lock"
 	quotaReservation "go.lumeweb.com/portal-plugin-quota/internal/reservation"
 	"go.lumeweb.com/portal-plugin-quota/internal/service/managers"
@@ -785,10 +784,10 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 	}
 
 	if update.QuotaPlanID != nil {
-		event := quotaEvent.NewQuotaPlanChangedEvent(ctx, userID, oldPlanID, update.QuotaPlanID)
-		if err := core.Fire[quotaEvent.QuotaPlanChangedEvent](
+		event := pluginCore.NewQuotaPlanChangedEvent(ctx, userID, oldPlanID, update.QuotaPlanID)
+		if err := core.Fire[pluginCore.QuotaPlanChangedEvent](
 			s.Context(),
-			quotaEvent.EventQuotaPlanChanged,
+			pluginCore.EventQuotaPlanChanged,
 			event,
 		); err != nil {
 			s.Logger().Error("failed to emit quota plan changed event", zap.Error(err))
@@ -824,10 +823,10 @@ func (s *QuotaServiceDefault) ResetUserQuotaPlan(ctx context.Context, userID uin
 		return fmt.Errorf("failed to reset user quota plan: %w", err)
 	}
 
-	event := quotaEvent.NewQuotaPlanChangedEvent(ctx, userID, oldPlanID, nil)
-	if err := core.Fire[quotaEvent.QuotaPlanChangedEvent](
+	event := pluginCore.NewQuotaPlanChangedEvent(ctx, userID, oldPlanID, nil)
+	if err := core.Fire[pluginCore.QuotaPlanChangedEvent](
 		s.Context(),
-		quotaEvent.EventQuotaPlanChanged,
+		pluginCore.EventQuotaPlanChanged,
 		event,
 	); err != nil {
 		s.Logger().Error("failed to emit quota plan changed event", zap.Error(err))


### PR DESCRIPTION
Move event definitions from internal/event to core/ so other plugins can subscribe to quota plan changes. Update quota service imports to use pluginCore instead of internal event package.

- `develop` <!-- branch-stack -->
  - **refactor: move QuotaPlanChangedEvent to core package for cross-plugin access** :point\_left:


---

<!-- kody-pr-summary:start -->
Move `QuotaPlanChangedEvent` and related types from the `internal/event` package to the `core` package, enabling cross-plugin access to quota plan change events. Since Go's `internal` packages are inaccessible to external modules, this refactoring exposes the event types (`QuotaPlanChangedEvent`, `NewQuotaPlanChangedEvent`, `OnQuotaPlanChanged`, `EventQuotaPlanChanged`) so that other plugins can listen for and react to quota plan changes. All internal references in the quota service have been updated accordingly.
<!-- kody-pr-summary:end -->