### PR TITLE
feat(core): add redundancy-based storage scaling

### DIFF
--- a/core/redundancy.go
+++ b/core/redundancy.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+
+	koanfJSON "github.com/knadh/koanf/parsers/json"
+	"github.com/knadh/koanf/providers/confmap"
+	"github.com/knadh/koanf/providers/rawbytes"
+	"github.com/knadh/koanf/v2"
+	"go.lumeweb.com/portal-plugin-quota/internal"
+	"gorm.io/datatypes"
+)
+
+// CalculateScaledSize calculates the scaled storage size based on redundancy metadata.
+// Actual redundancy is calculated as totalSectors/minShards.
+// The scaled size is dataSize * (actualRedundancy / DEFAULT_REDUNDANCY).
+// This allows quota to fairly account for storage based on actual redundancy.
+func CalculateScaledSize(dataSize uint64, minShards, totalSectors uint64) uint64 {
+	if minShards == 0 || totalSectors == 0 {
+		return dataSize
+	}
+	actualRedundancy := float64(totalSectors) / float64(minShards)
+	scaled := float64(dataSize) * (actualRedundancy / float64(internal.DEFAULT_REDUNDANCY))
+	return uint64(scaled)
+}
+
+// SlabMetadata represents siad/renterd-style storage redundancy metadata.
+// This data is typically stored in upload.Metadata['redundancy'] as JSON.
+type SlabMetadata struct {
+	MinShards    uint64 `json:"minShards"`    // Minimum shards needed for recovery
+	TotalSectors uint64 `json:"totalSectors"` // Total sectors stored (includes redundancy)
+	DataSize     uint64 `json:"dataSize"`     // Original data size before redundancy
+	TotalSize    uint64 `json:"totalSize"`    // Total size on disk with all sectors
+}
+
+// ParseRedundancyMetadata parses redundancy data from upload.Metadata['redundancy'].
+// The input is expected to be a map with 'redundancy' key containing SlabMetadata fields.
+func ParseRedundancyMetadata(metadata map[string]interface{}) (*SlabMetadata, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("nil metadata")
+	}
+
+	redundancy, ok := metadata["redundancy"]
+	if !ok {
+		return nil, fmt.Errorf("no redundancy field in metadata")
+	}
+
+	k := koanf.New(".")
+
+	switch data := redundancy.(type) {
+	case map[string]interface{}:
+		if err := k.Load(confmap.Provider(data, ""), nil); err != nil {
+			return nil, fmt.Errorf("failed to load redundancy metadata: %w", err)
+		}
+	case string:
+		if err := k.Load(rawbytes.Provider([]byte(data)), koanfJSON.Parser()); err != nil {
+			return nil, fmt.Errorf("failed to parse redundancy metadata string: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported redundancy metadata type: %T", redundancy)
+	}
+
+	var meta SlabMetadata
+	meta.MinShards = uint64(k.Int("minShards"))
+	meta.TotalSectors = uint64(k.Int("totalSectors"))
+	meta.DataSize = uint64(k.Int("dataSize"))
+	meta.TotalSize = uint64(k.Int("totalSize"))
+
+	return &meta, nil
+}
+
+// EncodeSlabMetadata encodes a SlabMetadata into an upload's Metadata field.
+// It preserves existing metadata keys and sets/updates the "redundancy" key.
+func EncodeSlabMetadata(meta datatypes.JSON, slab SlabMetadata) (datatypes.JSON, error) {
+	var metadataMap map[string]interface{}
+	if len(meta) > 0 {
+		if err := json.Unmarshal(meta, &metadataMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal existing metadata: %w", err)
+		}
+	}
+	if metadataMap == nil {
+		metadataMap = make(map[string]interface{})
+	}
+
+	metadataMap["redundancy"] = slab
+
+	updated, err := json.Marshal(metadataMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata with redundancy: %w", err)
+	}
+
+	return updated, nil
+}

--- a/core/redundancy_test.go
+++ b/core/redundancy_test.go
@@ -1,0 +1,233 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal-plugin-quota/internal"
+	"gorm.io/datatypes"
+)
+
+func TestCalculateScaledSize(t *testing.T) {
+	tests := []struct {
+		name         string
+		dataSize     uint64
+		minShards    uint64
+		totalSectors uint64
+		want         uint64
+	}{
+		{
+			name:         "default_redundancy_no_scaling",
+			dataSize:     1000,
+			minShards:    10,
+			totalSectors: 30,
+			want:         1000, // 30/10=3.0, 3.0/3.0=1.0, 1000*1.0=1000
+		},
+		{
+			name:         "higher_redundancy_scales_up",
+			dataSize:     1000,
+			minShards:    10,
+			totalSectors: 40,
+			want:         1333, // 40/10=4.0, 4.0/3.0≈1.333, 1000*1.333≈1333
+		},
+		{
+			name:         "lower_redundancy_scales_down",
+			dataSize:     1000,
+			minShards:    10,
+			totalSectors: 20,
+			want:         666, // 20/10=2.0, 2.0/3.0≈0.666, 1000*0.666≈666
+		},
+		{
+			name:         "zero_minShards_fallback",
+			dataSize:     1000,
+			minShards:    0,
+			totalSectors: 30,
+			want:         1000,
+		},
+		{
+			name:         "zero_totalSectors_fallback",
+			dataSize:     1000,
+			minShards:    10,
+			totalSectors: 0,
+			want:         1000,
+		},
+		{
+			name:         "zero_dataSize",
+			dataSize:     0,
+			minShards:    10,
+			totalSectors: 30,
+			want:         0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateScaledSize(tt.dataSize, tt.minShards, tt.totalSectors)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCalculateScaledSize_DefaultRedundancyValue(t *testing.T) {
+	assert.Equal(t, 3.0, internal.DEFAULT_REDUNDANCY)
+}
+
+func TestParseRedundancyMetadata(t *testing.T) {
+	t.Run("valid_map_input", func(t *testing.T) {
+		metadata := map[string]interface{}{
+			"redundancy": map[string]interface{}{
+				"minShards":    10,
+				"totalSectors": 30,
+				"dataSize":     1000,
+				"totalSize":    3000,
+			},
+		}
+
+		got, err := ParseRedundancyMetadata(metadata)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(10), got.MinShards)
+		assert.Equal(t, uint64(30), got.TotalSectors)
+		assert.Equal(t, uint64(1000), got.DataSize)
+		assert.Equal(t, uint64(3000), got.TotalSize)
+	})
+
+	t.Run("valid_string_input", func(t *testing.T) {
+		metadata := map[string]interface{}{
+			"redundancy": `{"minShards":5,"totalSectors":15,"dataSize":500,"totalSize":1500}`,
+		}
+
+		got, err := ParseRedundancyMetadata(metadata)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), got.MinShards)
+		assert.Equal(t, uint64(15), got.TotalSectors)
+		assert.Equal(t, uint64(500), got.DataSize)
+		assert.Equal(t, uint64(1500), got.TotalSize)
+	})
+
+	t.Run("nil_metadata", func(t *testing.T) {
+		_, err := ParseRedundancyMetadata(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil metadata")
+	})
+
+	t.Run("missing_redundancy_key", func(t *testing.T) {
+		metadata := map[string]interface{}{
+			"other": "value",
+		}
+		_, err := ParseRedundancyMetadata(metadata)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no redundancy field")
+	})
+
+	t.Run("unsupported_type", func(t *testing.T) {
+		metadata := map[string]interface{}{
+			"redundancy": 42,
+		}
+		_, err := ParseRedundancyMetadata(metadata)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported redundancy metadata type")
+	})
+
+	t.Run("invalid_json_string", func(t *testing.T) {
+		metadata := map[string]interface{}{
+			"redundancy": "{invalid json}",
+		}
+		_, err := ParseRedundancyMetadata(metadata)
+		assert.Error(t, err)
+	})
+}
+
+func TestEncodeSlabMetadata(t *testing.T) {
+	t.Run("encode_into_empty_metadata", func(t *testing.T) {
+		meta := datatypes.JSON(nil)
+		slab := SlabMetadata{
+			MinShards:    10,
+			TotalSectors: 30,
+			DataSize:     1000,
+			TotalSize:    3000,
+		}
+
+		result, err := EncodeSlabMetadata(meta, slab)
+		require.NoError(t, err)
+
+		var parsed map[string]interface{}
+		require.NoError(t, json.Unmarshal(result, &parsed))
+
+		redundancy, ok := parsed["redundancy"]
+		require.True(t, ok)
+
+		got, err := ParseRedundancyMetadata(parsed)
+		require.NoError(t, err)
+		assert.Equal(t, slab, *got)
+		_ = redundancy
+	})
+
+	t.Run("encode_preserves_existing_keys", func(t *testing.T) {
+		existing := datatypes.JSON(`{"foo":"bar","baz":123}`)
+		slab := SlabMetadata{
+			MinShards:    5,
+			TotalSectors: 15,
+			DataSize:     500,
+			TotalSize:    1500,
+		}
+
+		result, err := EncodeSlabMetadata(existing, slab)
+		require.NoError(t, err)
+
+		var parsed map[string]interface{}
+		require.NoError(t, json.Unmarshal(result, &parsed))
+
+		assert.Equal(t, "bar", parsed["foo"])
+		assert.True(t, parsed["redundancy"] != nil)
+	})
+
+	t.Run("encode_overwrites_existing_redundancy", func(t *testing.T) {
+		existing := datatypes.JSON(`{"redundancy":{"minShards":1,"totalSectors":1,"dataSize":1,"totalSize":1}}`)
+		slab := SlabMetadata{
+			MinShards:    10,
+			TotalSectors: 30,
+			DataSize:     1000,
+			TotalSize:    3000,
+		}
+
+		result, err := EncodeSlabMetadata(existing, slab)
+		require.NoError(t, err)
+
+		var parsed map[string]interface{}
+		require.NoError(t, json.Unmarshal(result, &parsed))
+
+		got, err := ParseRedundancyMetadata(parsed)
+		require.NoError(t, err)
+		assert.Equal(t, slab, *got)
+	})
+
+	t.Run("invalid_existing_metadata", func(t *testing.T) {
+		existing := datatypes.JSON(`not json`)
+		slab := SlabMetadata{MinShards: 1}
+
+		_, err := EncodeSlabMetadata(existing, slab)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal existing metadata")
+	})
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	original := SlabMetadata{
+		MinShards:    10,
+		TotalSectors: 30,
+		DataSize:     1000,
+		TotalSize:    3000,
+	}
+
+	encoded, err := EncodeSlabMetadata(nil, original)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(encoded, &parsed))
+
+	decoded, err := ParseRedundancyMetadata(parsed)
+	require.NoError(t, err)
+	assert.Equal(t, original, *decoded)
+}

--- a/core/types.go
+++ b/core/types.go
@@ -25,9 +25,9 @@ const (
 // QuotaCheckResult represents the result of a quota check
 type QuotaCheckResult struct {
 	Allowed     bool
-	Reason      QuotaCheckReason   // "OK", "LIMIT_EXCEEDED", "ALLOWANCE_DEPLETED", "WARNING_THRESHOLD", etc.
+	Reason      QuotaCheckReason // "OK", "LIMIT_EXCEEDED", "ALLOWANCE_DEPLETED", "WARNING_THRESHOLD", etc.
 	Details     QuotaCheckDetails
-	Reservation Reservation         // Reservation if quota was reserved (optional)
+	Reservation Reservation      // Reservation if quota was reserved (optional)
 }
 
 // ReleaseReservation releases the quota reservation if one exists.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -2,3 +2,9 @@ package internal
 
 const PluginName = "quota"
 const ProtocolName = "quota"
+
+// DEFAULT_REDUNDANCY is the baseline redundancy factor used for calculating
+// normalized storage consumption. When actual redundancy differs from this value,
+// the recorded storage bytes are scaled proportionally.
+// A value of 1.0 means no redundancy (1 copy), higher values mean more redundancy.
+const DEFAULT_REDUNDANCY = 3.0

--- a/internal/service/quota/event_listeners.go
+++ b/internal/service/quota/event_listeners.go
@@ -2,10 +2,12 @@ package quota
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
 
+	pluginCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/core"
 	portalModels "go.lumeweb.com/portal/db/models"
 	portalEvent "go.lumeweb.com/portal/event"
@@ -99,23 +101,8 @@ func (s *QuotaServiceDefault) registerEventListeners() {
 // when converting to int64 for RecordStorageChange. In such cases, the size is capped at
 // math.MaxInt64 to prevent overflow and the error is logged.
 func (s *QuotaServiceDefault) getUploadSize(ctx context.Context, pin *portalModels.Pin) (uint64, error) {
-	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.getUploadSize")
-	defer span.End()
-
-	uploadService := core.GetService[core.UploadService](s.Context(), core.UPLOAD_SERVICE)
-	if uploadService == nil {
-		s.Logger().Error("Upload service not available",
-			zap.Uint("pinID", pin.ID),
-			zap.Uint("uploadID", pin.UploadID))
-		return 0, errServiceUnavailable
-	}
-
-	upload, err := uploadService.GetUploadByID(ctx, pin.UploadID)
+	upload, err := s.getUploadForPin(ctx, pin)
 	if err != nil {
-		s.Logger().Error("Failed to get upload for pin",
-			zap.Uint("pinID", pin.ID),
-			zap.Uint("uploadID", pin.UploadID),
-			zap.Error(err))
 		return 0, err
 	}
 
@@ -129,6 +116,66 @@ func (s *QuotaServiceDefault) getUploadSize(ctx context.Context, pin *portalMode
 	}
 
 	return upload.Size, nil
+}
+
+// getUploadForPin retrieves the upload for a given pin.
+func (s *QuotaServiceDefault) getUploadForPin(ctx context.Context, pin *portalModels.Pin) (*portalModels.Upload, error) {
+	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.getUploadForPin")
+	defer span.End()
+
+	uploadService := core.GetService[core.UploadService](s.Context(), core.UPLOAD_SERVICE)
+	if uploadService == nil {
+		s.Logger().Error("Upload service not available",
+			zap.Uint("pinID", pin.ID),
+			zap.Uint("uploadID", pin.UploadID))
+		return nil, errServiceUnavailable
+	}
+
+	upload, err := uploadService.GetUploadByID(ctx, pin.UploadID)
+	if err != nil {
+		s.Logger().Error("Failed to get upload for pin",
+			zap.Uint("pinID", pin.ID),
+			zap.Uint("uploadID", pin.UploadID),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return upload, nil
+}
+
+// getStorageSizeToRecord calculates the effective storage size to record.
+// It checks for redundancy metadata in the upload's Metadata field and scales
+// the size accordingly. If no metadata exists, it returns the original size.
+func (s *QuotaServiceDefault) getStorageSizeToRecord(upload *portalModels.Upload, defaultSize uint64) uint64 {
+	// Check if upload has metadata
+	var metadataMap map[string]interface{}
+	if err := json.Unmarshal([]byte(upload.Metadata), &metadataMap); err != nil {
+		s.Logger().Debug("Upload metadata not parseable for redundancy scaling",
+			zap.Uint("uploadID", upload.ID),
+			zap.Error(err))
+		return defaultSize
+	}
+
+	// Parse redundancy metadata
+	slabMeta, err := pluginCore.ParseRedundancyMetadata(metadataMap)
+	if err != nil {
+		s.Logger().Debug("No redundancy metadata found for upload",
+			zap.Uint("uploadID", upload.ID),
+			zap.Error(err))
+		return defaultSize
+	}
+
+	// Calculate scaled size using DataSize (original data) and redundancy factors
+	scaled := pluginCore.CalculateScaledSize(upload.Size, slabMeta.MinShards, slabMeta.TotalSectors)
+
+	s.Logger().Debug("Scaled storage size based on redundancy metadata",
+		zap.Uint("uploadID", upload.ID),
+		zap.Uint64("originalSize", upload.Size),
+		zap.Uint64("scaledSize", scaled),
+		zap.Uint64("minShards", slabMeta.MinShards),
+		zap.Uint64("totalSectors", slabMeta.TotalSectors))
+
+	return scaled
 }
 
 // handleUploadCompleted handles the upload completed event
@@ -205,10 +252,24 @@ func (s *QuotaServiceDefault) handleStorageObjectPinned(ctx context.Context, pin
 	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.handleStorageObjectPinned")
 	defer span.End()
 
-	size, err := s.getUploadSize(ctx, pin)
-	if err != nil && !errors.Is(err, errUploadSizeOverflow) {
+	upload, err := s.getUploadForPin(ctx, pin)
+	if err != nil {
 		return err
 	}
+
+	// Get the base size and apply redundancy scaling
+	size := upload.Size
+	if size > math.MaxInt64 {
+		s.Logger().Warn("Upload size exceeds maximum int64 value, capping for storage change",
+			zap.Uint("pinID", pin.ID),
+			zap.Uint("uploadID", pin.UploadID),
+			zap.Uint64("uploadSize", size),
+			zap.Int64("cappedSize", math.MaxInt64))
+		size = math.MaxInt64
+	}
+
+	// Apply redundancy scaling
+	scaledSize := s.getStorageSizeToRecord(upload, size)
 
 	// Create adapter for RecordStorageChange to match usageRecordingFunc signature
 	recordStorageFunc := func(ctx context.Context, userID uint, uploadID uint, bytes uint64, ip string) error {
@@ -220,7 +281,7 @@ func (s *QuotaServiceDefault) handleStorageObjectPinned(ctx context.Context, pin
 			ctx,
 			pin.UserID,
 			*reservationUUID,
-			size,
+			scaledSize,
 			true, // Storage pin is always successful
 			recordStorageFunc,
 			pin.UploadID,
@@ -233,9 +294,10 @@ func (s *QuotaServiceDefault) handleStorageObjectPinned(ctx context.Context, pin
 	s.Logger().Debug("Recording storage usage from pin event",
 		zap.Uint("userID", pin.UserID),
 		zap.Uint("uploadID", pin.UploadID),
-		zap.Uint64("bytes", size))
+		zap.Uint64("originalSize", size),
+		zap.Uint64("scaledSize", scaledSize))
 
-	return s.RecordStorageChange(ctx, pin.UserID, pin.UploadID, int64(size), ip)
+	return s.RecordStorageChange(ctx, pin.UserID, pin.UploadID, int64(scaledSize), ip)
 }
 
 // handleStorageObjectUnpinned handles the storage object unpinned event
@@ -243,16 +305,31 @@ func (s *QuotaServiceDefault) handleStorageObjectUnpinned(ctx context.Context, p
 	ctx, span := core.TraceMethod(ctx, "QuotaServiceDefault.handleStorageObjectUnpinned")
 	defer span.End()
 
-	size, err := s.getUploadSize(ctx, pin)
-	if err != nil && !errors.Is(err, errUploadSizeOverflow) {
+	upload, err := s.getUploadForPin(ctx, pin)
+	if err != nil {
 		return err
 	}
+
+	// Get the base size and apply redundancy scaling
+	size := upload.Size
+	if size > math.MaxInt64 {
+		s.Logger().Warn("Upload size exceeds maximum int64 value, capping for storage change",
+			zap.Uint("pinID", pin.ID),
+			zap.Uint("uploadID", pin.UploadID),
+			zap.Uint64("uploadSize", size),
+			zap.Int64("cappedSize", math.MaxInt64))
+		size = math.MaxInt64
+	}
+
+	// Apply redundancy scaling
+	scaledSize := s.getStorageSizeToRecord(upload, size)
 
 	s.Logger().Debug("Recording storage usage from unpin event",
 		zap.Uint("userID", pin.UserID),
 		zap.Uint("uploadID", pin.UploadID),
-		zap.Uint64("bytes", size))
+		zap.Uint64("originalSize", size),
+		zap.Uint64("scaledSize", scaledSize))
 
 	// Storage removal uses negative bytes
-	return s.RecordStorageChange(ctx, pin.UserID, pin.UploadID, -int64(size), ip)
+	return s.RecordStorageChange(ctx, pin.UserID, pin.UploadID, -int64(scaledSize), ip)
 }


### PR DESCRIPTION
- Add DEFAULT\_REDUNDANCY constant (3.0) for baseline redundancy factor
- Add SlabMetadata struct with MinShards, TotalSectors, DataSize, TotalSize fields
- Add CalculateScaledSize function to scale storage by actual vs default redundancy
- Add ParseRedundancyMetadata using koanf to read from upload.Metadata\["redundancy"]
- Add EncodeSlabMetadata helper to write redundancy data into upload metadata
- Integrate redundancy scaling in storage pin/unpin event handlers
- Add comprehensive unit tests for all redundancy functions

* `develop` <!-- branch-stack -->
  - **feat(core): add redundancy-based storage scaling** :point\_left:
