### PR TITLE
fix: enforce authentication middleware on admin routes

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -241,10 +241,12 @@ func (e *QuotaAdminExtension) buildMiddlewares() []echo.MiddlewareFunc {
 }
 
 func (e *QuotaAdminExtension) newRoute(method, path string, handler echo.HandlerFunc, opts ...router.SwaggerOption) router.Route {
-	return router.NewRoute(method, path, handler, 
+	routerOpts := []router.RouteOption{
 		router.WithAccess(core.ACCESS_ADMIN_ROLE),
+		router.WithMiddlewares(e.buildMiddlewares()...),
 		router.WithSwaggerOptions(opts...),
-	)
+	}
+	return router.NewRoute(method, path, handler, routerOpts...)
 }
 
 // Quota Plan Management Handlers

--- a/internal/api/test_helpers_test.go
+++ b/internal/api/test_helpers_test.go
@@ -87,6 +87,10 @@ func (h *QuotaTestHelper) SetupAuth() {
 
 // ExecuteRequest executes an API request and records the response
 func (h *QuotaTestHelper) ExecuteRequest(method, url string, body []byte) *httptest.ResponseRecorder {
+	// Ensure authentication is set up for admin routes
+	if h.authToken == "" {
+		h.SetupAuth()
+	}
 	req := h.NewAuthorizedRequest(method, url, body)
 	rec := httptest.NewRecorder()
 	h.ctx.Router().ServeHTTP(rec, req)


### PR DESCRIPTION
Fix security issue where admin extension routes lacked authentication enforcement.

- Add router.WithMiddlewares() to newRoute() to apply auth and access middleware
- Update test helper to automatically set up authentication for admin API tests
- All admin routes (/api/quota/\*) now require valid admin authentication

* `develop` <!-- branch-stack -->
  - **fix: enforce authentication middleware on admin routes** :point\_left:


---

<!-- kody-pr-summary:start -->
## Fix: Enforce authentication middleware on admin routes

The admin routes were missing authentication middleware enforcement. While `buildMiddlewares()` was defined and included authentication logic, the middlewares were never actually applied to the routes created by `newRoute()` — only access role checks and swagger options were being passed to `router.NewRoute()`.

This fix adds `router.WithMiddlewares(e.buildMiddlewares()...)` to the route options, ensuring that authentication middleware is properly enforced on all admin routes. Additionally, the test helper's `ExecuteRequest` method now auto-initializes authentication if the auth token is empty, preventing test failures from unauthenticated requests to admin endpoints.
<!-- kody-pr-summary:end -->