### PR TITLE
fix(core): use target API subdomain for admin route registration

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -76,7 +76,7 @@ func (e *QuotaAdminExtension) Configure(gRouter router.Router, accessSvc core.Ac
 // registerQuotaHandlers registers quota management routes
 func (e *QuotaAdminExtension) registerQuotaHandlers(gRouter router.Router, accessSvc core.AccessService) error {
 	routes := e.buildRoutes()
-	apiGroup := internal.ProtocolName
+	apiGroup := core.GetAPI(e.TargetAPI()).Subdomain()
 	
 	e.Logger().Info("Registering admin extension routes", 
 		zap.String("group", apiGroup),


### PR DESCRIPTION
- Replace hardcoded internal.ProtocolName with core.GetAPI(e.TargetAPI()).Subdomain() in AdminExtension
- Matches quota\_extension.go pattern for consistent route registration

* `develop` <!-- branch-stack -->
  - **fix(core): use target API subdomain for admin route registration** :point\_left:


---

<!-- kody-pr-summary:start -->
## Fix: Use target API subdomain for admin route registration

The admin extension route registration was incorrectly using `internal.ProtocolName` as the API group, which would register routes under the wrong group. This change updates it to use `core.GetAPI(e.TargetAPI()).Subdomain()`, ensuring the admin routes are registered under the correct API subdomain group corresponding to the target API.
<!-- kody-pr-summary:end -->