### PR TITLE
chore: Run CI test and build workflows only on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
- Remove push triggers from test.yaml and build.yml
- Keep pull_request and workflow_dispatch triggers for manual runs

---

<!-- kody-pr-summary:start -->
Update CI workflows to only trigger on pull requests

Remove `push` event triggers from both the Build and Test workflows, so they only run on `pull_request` (and manual `workflow_dispatch` for the Build workflow). This reduces unnecessary CI runs by skipping build and test jobs on direct pushes.
<!-- kody-pr-summary:end -->