### PR TITLE
fix: use Attrs() instead of init struct in FirstOrCreate to prevent duplicate key violations

### DIFF
--- a/internal/service/managers/config.go
+++ b/internal/service/managers/config.go
@@ -79,8 +79,10 @@ func (cm *ConfigManager) GetUserQuotaConfig(ctx context.Context, userID uint) (*
 	// Use FirstOrCreate to atomically handle the get-or-create logic.
 	// This prevents a race condition where two concurrent requests for a new user
 	// both try to create the config, causing one to fail.
+	// Use Attrs to set defaults on create without adding them to the WHERE clause,
+	// so that an existing config with different field values is still found.
 	err := db.RetryableTransaction(ctx, cm.DB(), func(tx *gorm.DB) *gorm.DB {
-		return tx.Where(&pluginModels.UserQuotaConfig{UserID: userID}).FirstOrCreate(defaultConfig)
+		return tx.Where("user_id = ?", userID).Attrs(defaultConfig).FirstOrCreate(defaultConfig)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find or create default user quota config: %w", err)

--- a/internal/service/managers/config_test.go
+++ b/internal/service/managers/config_test.go
@@ -530,3 +530,40 @@ func TestConfigManager_GetUserAllowanceGrants_NoGrants_Success(t *testing.T) {
 		assert.Len(t, grants, 0)
 	}, pluginTesting.TestOptions())
 }
+
+// TestConfigManager_GetUserQuotaConfig_ExistingConfigDifferentPolicy_FindsExisting tests
+// that GetUserQuotaConfig finds an existing config even when its enforcement_policy
+// differs from the default. This is a regression test for a bug where FirstOrCreate
+// included enforcement_policy in the WHERE clause, causing it to miss existing rows
+// and attempt a duplicate INSERT.
+func TestConfigManager_GetUserQuotaConfig_ExistingConfigDifferentPolicy_FindsExisting(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		mockLimitResolver := pluginCore.NewMockLimitResolver(tb)
+		mockPlanManager := pluginCore.NewMockQuotaPlanManager(tb)
+		mockPolicyEnforcer := pluginCore.NewMockPolicyEnforcer(tb)
+
+		policyEnforcers := map[pluginModels.EnforcementPolicy]pluginCore.PolicyEnforcer{
+			pluginModels.EnforcementPolicyUnlimited: mockPolicyEnforcer,
+		}
+
+		configManager := NewConfigManager(ctx, mockLimitResolver, mockPlanManager, policyEnforcers)
+
+		userID := uint(2)
+
+		// Create config with UNLIMITED policy (different from default HARD_LIMITS)
+		userConfig := &pluginModels.UserQuotaConfig{
+			UserID:            userID,
+			EnforcementPolicy: pluginModels.EnforcementPolicyUnlimited,
+		}
+		err := ctx.DB().Create(userConfig).Error
+		require.NoError(t, err)
+
+		// GetUserQuotaConfig should find the existing row, not try to create a new one
+		mockPlanManager.EXPECT().GetDefaultQuotaPlan(mock.Anything).Return((*pluginModels.QuotaPlan)(nil), fmt.Errorf("no default plan"))
+
+		config, err := configManager.GetUserQuotaConfig(ctx, userID)
+		require.NoError(t, err)
+		assert.Equal(t, userID, config.UserID)
+		assert.Equal(t, pluginModels.EnforcementPolicyUnlimited, config.EnforcementPolicy)
+	}, pluginTesting.TestOptions())
+}

--- a/internal/service/managers/usage.go
+++ b/internal/service/managers/usage.go
@@ -83,14 +83,16 @@ func (um *UsageManager) GetUserQuotaConfig(ctx context.Context, userID uint) (*p
 	}
 
 	// Use FirstOrCreate to prevent race conditions when multiple goroutines
-	// try to create the same user config simultaneously
-	cfg := pluginModels.UserQuotaConfig{
-		UserID:            userID,
-		EnforcementPolicy: pluginModels.EnforcementPolicyHardLimits,
-	}
+	// try to create the same user config simultaneously.
+	// Use Attrs to set defaults on create without adding them to the WHERE clause,
+	// so that an existing config with a different enforcement_policy is still found.
+	var cfg pluginModels.UserQuotaConfig
 
 	if err := db.RetryableTransaction(ctx, um.DB(), func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("user_id = ?", userID).FirstOrCreate(&cfg)
+		return tx.Where("user_id = ?", userID).Attrs(&pluginModels.UserQuotaConfig{
+			UserID:            userID,
+			EnforcementPolicy: pluginModels.EnforcementPolicyHardLimits,
+		}).FirstOrCreate(&cfg)
 	}); err != nil {
 		return nil, fmt.Errorf("failed to get or create user quota config: %w", err)
 	}

--- a/internal/service/quota/quota.go
+++ b/internal/service/quota/quota.go
@@ -630,17 +630,19 @@ func (s *QuotaServiceDefault) AssignUserToPlan(ctx context.Context, userID uint,
 
 	// Perform both operations atomically in a transaction
 	return db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		// First, ensure the user has a quota config
-		result := tx.Where("user_id = ?", userID).FirstOrCreate(&models.UserQuotaConfig{
+		// First, ensure the user has a quota config.
+		// Use Attrs to set defaults on create without adding them to the WHERE clause.
+		var config models.UserQuotaConfig
+		result := tx.Where("user_id = ?", userID).Attrs(&models.UserQuotaConfig{
 			UserID:            userID,
 			EnforcementPolicy: models.EnforcementPolicyHardLimits,
-		})
+		}).FirstOrCreate(&config)
 		if result.Error != nil {
 			return result
 		}
 
 		// Update the user's quota config with the plan ID
-		return tx.Model(&models.UserQuotaConfig{}).Where("user_id = ?", userID).UpdateColumn("quota_plan_id", planID)
+		return tx.Model(&config).UpdateColumn("quota_plan_id", planID)
 	})
 
 }
@@ -760,12 +762,14 @@ func (s *QuotaServiceDefault) UpdateUserQuotaConfig(ctx context.Context, userID 
 	var oldPlanID *uint64
 
 	// Ensure the user has a quota config first, then apply updates
+	// Use Attrs to set defaults on create without adding them to the WHERE clause,
+	// so that an existing config with a different enforcement_policy is still found.
 	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 		var config models.UserQuotaConfig
-		result := tx.Where("user_id = ?", userID).FirstOrCreate(&config, &models.UserQuotaConfig{
+		result := tx.Where("user_id = ?", userID).Attrs(&models.UserQuotaConfig{
 			UserID:            userID,
 			EnforcementPolicy: models.EnforcementPolicyHardLimits,
-		})
+		}).FirstOrCreate(&config)
 		if result.Error != nil {
 			return result
 		}

--- a/internal/service/quota/quota_test.go
+++ b/internal/service/quota/quota_test.go
@@ -1579,3 +1579,117 @@ func TestResetUserQuotaPlan_NonExistentUser_NoError(t *testing.T) {
 	}, testOptions())
 }
 
+// TestUpdateUserQuotaConfig_SecondUpdateDifferentPolicy_Succeeds tests that calling
+// UpdateUserQuotaConfig twice with different enforcement policies does not cause a
+// duplicate key violation. This is a regression test for a bug where FirstOrCreate
+// included enforcement_policy in the WHERE clause, so after the first update changed
+// the policy away from HARD_LIMITS (the init default), a second call would not find
+// the existing row and attempt a duplicate INSERT.
+func TestUpdateUserQuotaConfig_SecondUpdateDifferentPolicy_Succeeds(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		userID := uint(5001)
+
+		// First update: set enforcement policy to UNLIMITED (creates the config)
+		unlimitedPolicy := pluginModels.EnforcementPolicyUnlimited
+		update1 := &pluginCore.UserQuotaConfigUpdate{
+			EnforcementPolicy: &unlimitedPolicy,
+		}
+		config1, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update1)
+		require.NoError(t, err)
+		require.NotNil(t, config1)
+		assert.Equal(t, unlimitedPolicy, config1.EnforcementPolicy)
+
+		// Second update: change enforcement policy to THRESHOLD (should find existing row)
+		thresholdPolicy := pluginModels.EnforcementPolicyThreshold
+		update2 := &pluginCore.UserQuotaConfigUpdate{
+			EnforcementPolicy: &thresholdPolicy,
+		}
+		config2, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update2)
+		require.NoError(t, err)
+		require.NotNil(t, config2)
+		assert.Equal(t, thresholdPolicy, config2.EnforcementPolicy)
+	}, testOptions())
+}
+
+// TestUpdateUserQuotaConfig_RepeatedUpdateSamePolicy_Succeeds tests that calling
+// UpdateUserQuotaConfig multiple times with the same policy does not cause a
+// duplicate key violation.
+func TestUpdateUserQuotaConfig_RepeatedUpdateSamePolicy_Succeeds(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		userID := uint(5002)
+
+		unlimitedPolicy := pluginModels.EnforcementPolicyUnlimited
+		update := &pluginCore.UserQuotaConfigUpdate{
+			EnforcementPolicy: &unlimitedPolicy,
+		}
+
+		// First call creates the config
+		config1, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+		require.NoError(t, err)
+		require.NotNil(t, config1)
+
+		// Second call should find the existing config and update it
+		config2, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+		require.NoError(t, err)
+		require.NotNil(t, config2)
+		assert.Equal(t, unlimitedPolicy, config2.EnforcementPolicy)
+
+		// Third call should also work
+		config3, err := quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+		require.NoError(t, err)
+		require.NotNil(t, config3)
+		assert.Equal(t, unlimitedPolicy, config3.EnforcementPolicy)
+	}, testOptions())
+}
+
+// TestAssignUserToPlan_AfterPolicyChange_Succeeds tests that AssignUserToPlan
+// works when a user's config already has a different enforcement policy than
+// the init default (HARD_LIMITS). This is a regression test for the same
+// FirstOrCreate WHERE clause bug.
+func TestAssignUserToPlan_AfterPolicyChange_Succeeds(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		quotaService := core.GetService[pluginCore.QuotaService](ctx, pluginCore.QUOTA_SERVICE).(*QuotaServiceDefault)
+
+		// Arrange - Create a plan
+		plan := &pluginModels.QuotaPlan{
+			Name:                "Test Plan For Policy Change",
+			Description:         "Plan for testing policy change",
+			StorageLimitBytes:   10737418240,
+			UploadLimitBytes:    104857600,
+			DownloadLimitBytes:  524288000,
+			WindowType:          pluginModels.WindowTypeCalendarDay,
+			IsDefault:           false,
+			IsActive:            new(bool),
+		}
+		*plan.IsActive = true
+		err := quotaService.CreateQuotaPlan(ctx, plan)
+		require.NoError(t, err)
+
+		userID := uint(5003)
+
+		// Set user's policy to UNLIMITED (different from AssignUserToPlan's init default of HARD_LIMITS)
+		unlimitedPolicy := pluginModels.EnforcementPolicyUnlimited
+		update := &pluginCore.UserQuotaConfigUpdate{
+			EnforcementPolicy: &unlimitedPolicy,
+		}
+		_, err = quotaService.UpdateUserQuotaConfig(ctx, userID, update)
+		require.NoError(t, err)
+
+		// Act - Assign user to plan (should find existing config, not try to INSERT)
+		err = quotaService.AssignUserToPlan(ctx, userID, plan.ID)
+
+		// Assert
+		require.NoError(t, err)
+
+		config, err := quotaService.GetQuotaConfig(ctx, userID)
+		require.NoError(t, err)
+		assert.NotNil(t, config.QuotaPlanID)
+		assert.Equal(t, uint64(plan.ID), *config.QuotaPlanID)
+		assert.Equal(t, unlimitedPolicy, config.EnforcementPolicy)
+	}, testOptions())
+}
+


### PR DESCRIPTION
- FirstOrCreate with init struct uses all non-zero fields as WHERE conditions
- After updating enforcement\_policy from HARD\_LIMITS, subsequent calls miss the existing row
- Missed row triggers a duplicate INSERT, violating the user\_id\_live unique constraint
- Replace init struct pattern with GORM's Attrs(), which sets values on create without affecting WHERE
- Applied to UpdateUserQuotaConfig, AssignUserToPlan, UsageManager.GetUserQuotaConfig, ConfigManager.GetUserQuotaConfig
- Added 4 regression tests covering repeated updates with different enforcement policies

* `develop` <!-- branch-stack -->
  - **fix: use Attrs() instead of init struct in FirstOrCreate to prevent duplicate key violations** :point\_left:

---

<!-- kody-pr-summary:start -->
Fix duplicate key violations in `FirstOrCreate` calls by using `Attrs()` for default values instead of including them in the `WHERE` clause.

When using GORM's `FirstOrCreate` with a struct initializer (e.g., `Where(&UserQuotaConfig{UserID: userID, EnforcementPolicy: HARD_LIMITS})`), all non-zero fields were included in the WHERE clause. This caused `FirstOrCreate` to fail to find existing user quota configs that had a different `EnforcementPolicy` than the default (`HARD_LIMITS`), resulting in a duplicate INSERT attempt and a unique key violation on `user_id`.

The fix moves default field values (like `EnforcementPolicy`) into `Attrs()`, which only applies them on creation without adding them to the lookup condition. The WHERE clause now only filters by `user_id`, ensuring existing configs are always found regardless of their current policy value.

Affected methods:
- `ConfigManager.GetUserQuotaConfig`
- `UsageManager.GetUserQuotaConfig`
- `QuotaServiceDefault.AssignUserToPlan`
- `QuotaServiceDefault.UpdateUserQuotaConfig`
<!-- kody-pr-summary:end -->